### PR TITLE
Add design/#986 (non-trapping float-to-int) to agenda

### DIFF
--- a/2017/CG-05.md
+++ b/2017/CG-05.md
@@ -56,7 +56,7 @@ Allen's paper on standards committee participation for newbees: http://wirfs-bro
     1. Working Group Formation
         * [Draft charter](https://webassembly.github.io/wg-charter/webassembly-wg-charter.html)
     1. Miscellaneous
-        * [Non-trapping float-to-int conversions](https://github.com/WebAssembly/design/issues/986)
+        * Non-trapping float-to-int conversions [[1](https://github.com/WebAssembly/design/issues/986),[2](https://github.com/WebAssembly/meetings/pull/3#issuecomment-302154544)]
 1. Closure
 
 ### Schedule constraints

--- a/2017/CG-05.md
+++ b/2017/CG-05.md
@@ -49,7 +49,7 @@ Please register before the event [here](https://goo.gl/forms/LQVhuRuI22lK8Umw1).
     1. Working Process
     1. Threads (Ben Smith)
        * [Proposal](https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md)
-    1. Non-trapping float-to-int conversions [[1](https://github.com/WebAssembly/design/issues/986),[2](https://github.com/WebAssembly/meetings/pull/3#issuecomment-302154544)] (30 minutes)
+    1. Non-trapping float-to-int conversions [[1](https://github.com/WebAssembly/design/issues/986),[2](https://github.com/WebAssembly/meetings/pull/3#issuecomment-302154544)] (Dan Gohman) : 30 minutes
     1. SIMD (Jakob Stoklund Olesen)
        * [Proposal](https://github.com/WebAssembly/simd/blob/master/README.md)
        * Brief overview of the proposal

--- a/2017/CG-05.md
+++ b/2017/CG-05.md
@@ -55,6 +55,8 @@ Allen's paper on standards committee participation for newbees: http://wirfs-bro
        * [Proposal](https://github.com/WebAssembly/simd/blob/master/proposals/simd/Overview.md)
     1. Working Group Formation
         * [Draft charter](https://webassembly.github.io/wg-charter/webassembly-wg-charter.html)
+    1. Miscellaneous
+        * [Non-trapping float-to-int conversions](https://github.com/WebAssembly/design/issues/986)
 1. Closure
 
 ### Schedule constraints

--- a/2017/CG-05.md
+++ b/2017/CG-05.md
@@ -51,12 +51,12 @@ Allen's paper on standards committee participation for newbees: http://wirfs-bro
     1. Working Process
     1. Threads
        * [Proposal](https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md)
+    1. Non-trapping float-to-int conversions [[1](https://github.com/WebAssembly/design/issues/986),[2](https://github.com/WebAssembly/meetings/pull/3#issuecomment-302154544)] (30 minutes)
     1. SIMD
        * [Proposal](https://github.com/WebAssembly/simd/blob/master/proposals/simd/Overview.md)
     1. Working Group Formation
         * [Draft charter](https://webassembly.github.io/wg-charter/webassembly-wg-charter.html)
-    1. Miscellaneous
-        * Non-trapping float-to-int conversions [[1](https://github.com/WebAssembly/design/issues/986),[2](https://github.com/WebAssembly/meetings/pull/3#issuecomment-302154544)]
+    
 1. Closure
 
 ### Schedule constraints

--- a/2017/CG-05.md
+++ b/2017/CG-05.md
@@ -61,7 +61,6 @@ Please register before the event [here](https://goo.gl/forms/LQVhuRuI22lK8Umw1).
        * Definition of performance benchmarks and acceptance criteria
     1. Working Group Formation
         * [Draft charter](https://webassembly.github.io/wg-charter/webassembly-wg-charter.html)
-    
 1. Closure
 
 ### Schedule constraints


### PR DESCRIPTION
(I'm not sure if this is the process for adding something to the agenda; let's see :)

This issue has been coming up a lot lately; this seems like a quick fix we could make that could yield immediate improvements in usability and performance.