### PR TITLE
Add type/memory/concurrency safety to the agenda

### DIFF
--- a/2017/CG-05.md
+++ b/2017/CG-05.md
@@ -69,11 +69,11 @@ Please register before the event [here](https://goo.gl/forms/LQVhuRuI22lK8Umw1).
          - [Lock-free guarantees for 8- and 16-bit atomics #19](https://github.com/WebAssembly/threads/issues/19)
          - [Blocking main thread in web embedding](https://github.com/WebAssembly/threads/issues/6)
          - [Thread-local and Shared Global variables](https://github.com/WebAssembly/threads/issues/4)
-         - [Consider supporting verifiably safe concurrency](https://github.com/WebAssembly/threads/issues/3)
          - [Native WebAssembly threads - needed for v1?](https://github.com/WebAssembly/threads/issues/8)
          - [Memory model standardization](https://github.com/WebAssembly/threads/issues/9)
          - [Memory orderings - sequential consistency only?](https://github.com/WebAssembly/threads/issues/13)
          - [How to test?](https://github.com/WebAssembly/threads/issues/10)
+    1. Gauge interest in verifiable type/memory/concurrency safety [[1](https://github.com/WebAssembly/gc/issues/4),[2](https://github.com/webassembly/threads/issues/3)] : 30 minutes
     1. Non-trapping float-to-int conversions [[1](https://github.com/WebAssembly/design/issues/986),[2](https://github.com/WebAssembly/meetings/pull/3#issuecomment-302154544)] (Dan Gohman) : 30 minutes
     1. SIMD (Jakob Stoklund Olesen)
        * [Proposal](https://github.com/WebAssembly/simd/blob/master/README.md)


### PR DESCRIPTION
Move safety to it's own topic, following threads.