### PR TITLE
Add a link to the non-trapping float-to-int conversion repo.

### DIFF
--- a/2017/CG-07.md
+++ b/2017/CG-07.md
@@ -53,6 +53,7 @@ Now closed.
     1. Adoption of the agenda
     1. Proposals and discussions
         1. Update on proposals from May: Non-trapping float-to-int conversions (Dan Gohman)
+            1. [Proposal Repo](https://github.com/WebAssembly/nontrapping-float-to-int-conversions)
         1. Update on proposals from May: threads (Ben Smith)
         1. Update on proposals from May: SIMD (James Zern + Brad Nelson)
             1. Presentation on WebP portable SIMD performance.


### PR DESCRIPTION
Pursuant to [the discussion at the recent meeting](https://github.com/WebAssembly/meetings/blob/master/2017/CG-07-06.md#float-to-int-conversion), I've now created a repo for the float-to-int conversion process.

Currently it contains a proposal document and proposed spec tests.