### PR TITLE
Add proposed time/place for next in-person meeting

### DIFF
--- a/2017/CG-08-08.md
+++ b/2017/CG-08-08.md
@@ -32,6 +32,7 @@ The meeting will be a Google Hangouts call.
             - public-webassembly-announce is moderated and low-traffic, auto-signs up all CG members.
         1. TBD
     1. Discuss timing of next in person CG meeting.
+        1. How does Nov 1-3 (or 2-3) in Mozilla's office in Mountain View sound?
     1. Content Security Policy and WASM
     1. Coordinating spec tests with WebPlatformTests
     1. [Presentation on JS/wasm modules integration](https://docs.google.com/presentation/d/11tHsNh2U9oEJD4lvV7XX2M22JnyeyyCHj1ncmspXjBU/edit?usp=sharing), mostly stage-setting (Domenic Denicola)


### PR DESCRIPTION
To give advanced warning so people can check ahead of time.