### PR TITLE
Fix broken link to the W3C Community Group page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WebAssembly meetings
 
 Information on official in-person WebAssembly meetings hosted by the W3C
-[Community Group](w3.org/community/webassembly/). Each meeting will have its own
+[Community Group](https://w3.org/community/webassembly/). Each meeting will have its own
 agenda published before the meeting, and minutes will be posted in the
 invitation document after the meeting, including topics discussions and
 decisions.


### PR DESCRIPTION
I was just browsing around here and noticed this link was relative and pointing back into this repo instead of going out to the https://w3.org website.