### PR TITLE
Add an agenda item for non-trapping float-to-int conversions.

### DIFF
--- a/2017/CG-11.md
+++ b/2017/CG-11.md
@@ -69,7 +69,9 @@ A list of near by hotels:
     1. Find volunteers for note taking
     1. Adoption of the agenda
     1. Proposals and discussions
-       1. TBD
+       1. Update on proposals from July: Non-trapping float-to-int conversions (Dan Gohman)
+            1. [Proposal Repo](https://github.com/WebAssembly/nontrapping-float-to-int-conversions)
+
     1. Adjourn
 * Thursday - November 2nd
     1. Find volunteers for note taking


### PR DESCRIPTION
The [nontrapping float-to-int conversion proposal](https://github.com/WebAssembly/nontrapping-float-to-int-conversions) now has spec text, an interpreter implementation, and testsuite coverage. There are presently no outstanding issues or PRs, and no other known outstanding concerns.
