### PR TITLE
Add agenda items for Nov 28

### DIFF
--- a/2017/CG-11-28.md
+++ b/2017/CG-11-28.md
@@ -30,6 +30,18 @@ The meeting will be a Google Hangouts call.
     1. Meeting times + collaborators in Asia-Pacific
        * Discussion of meeting time logistics
        * POLL: We should hold every third video call at an APAC friendly time.
+    1. The name of WebAssembly.Global
+       * See https://github.com/WebAssembly/threads/issues/49, discussion stalled
+       * Poll-worthy?
+    1. The type of immutable globals exported from instances
+       * See https://github.com/WebAssembly/threads/issues/73, discussion stalled
+       * Basically, either change existing API incompatibly or live with complex API
+       * Poll-worthy?
+    1. The type of the wake count argument and return value for atomic.wake
+       * Spec text changed this to i64 but poll at CG mildly in favor of older i32
+       * Would be good to nail this down now, code is landing in implementations
+       * Discussions bogged down on what TC39 may or may not want to do
+       * POLL: Revert to i32 with trapping in (the implausible) case of overflow
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
Two open issues on the Globals design and one on the Threads design.