### PR TITLE
Add an agenda item for renaming `current_memory`/`grow_memory`.

### DIFF
--- a/2018/CG-01-26.md
+++ b/2018/CG-01-26.md
@@ -33,6 +33,7 @@ The meeting will be a Google Hangouts call.
     1. Contribution policies and repos for tools targeting WebAssembly
         1. Currently Binaryen and WABT require contributors to join CG and agree to its IP policy (in addition to Apache2), which is a hurdle for some contributors. Should we continue this? What are the alternatives?
     1. [Combining Bulk Memory Operations and Conditional Segment Initialization proposals](https://github.com/WebAssembly/conditional-segment-initialization/issues/1)
+    1. Should `grow_memory`/`current_memory` be [renamed](https://github.com/WebAssembly/spec/issues/627)?
     1. Other items TBD
 1. Closure
 


### PR DESCRIPTION
See also https://github.com/WebAssembly/spec/issues/627.