### PR TITLE
Add non-trapping float-to-int conversions to the agenda.

### DIFF
--- a/2018/CG-04.md
+++ b/2018/CG-04.md
@@ -71,6 +71,8 @@ List of near by hotels:
           * Move to stage 2 or 3?
        1. [Garbage collection](https://github.com/WebAssembly/reference-types/blob/master/proposals/gc/Overview.md) (Andreas Rossberg)
           * Discuss road map, revisit in light of separated reference types proposal
+       1. [Nontrapping float-to-int conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions/) (Dan Gohman)
+          * Move to [stage 4](https://github.com/WebAssembly/meetings/blob/master/process/phases.md#4-standardize-the-feature-working-group)?
        1. TBD
     1. Adjourn
 * Wednesday - April 11th


### PR DESCRIPTION
[Non-trapping float-to-int conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions/) now meet the entry requirements for the [Standardize the Feature phase](https://github.com/WebAssembly/meetings/blob/master/process/phases.md#4-standardize-the-feature-working-group).

I arbitrarily added this for Tuesday, but it could go any time.