### PR TITLE
Proposed charter for debugging subgroup

### DIFF
--- a/subgroups/Debugging.md
+++ b/subgroups/Debugging.md
@@ -1,0 +1,57 @@
+# WebAssembly Debugging Subgroup Charter
+
+The Debugging Subgroup is a sub-organization of the
+[WebAssembly Community Group](https://www.w3.org/community/webassembly/) of the W3C.
+As such, it is intended that its charter align with that of the CG. In particular, 
+the sections of the CG charter relating to Community and Business Group Process,
+Contribution Mechanics, Transparency, and Decision Process also apply to the Subgroup.
+
+## Goals
+
+The mission of this sugbroup is to provide a forum for pre-standardization
+collaboration on debugging capabilities for WebAssembly programs.
+
+## Scope
+
+The Subgroup will consider topics related to debugging, profiling, or
+static analysis of WebAssembly programs, including:
+
+- File formats and encodings for WebAssembly debug information
+e.g. as custom sections in wasm executables or object files, 
+- Extensions to the WebAssembly text format for debug information
+- Extensions or modifications to
+- Interaction with browsers (e.g. developer tools, debugging, profiling)
+- Interaction with external debuggers and IDEs (VS Code), and
+debuggers running in the browser
+- Presentation of source, callstack, or debugging information in browsers, debuggers,
+or IDEs
+
+
+## Deliverables
+
+### Specifications
+The Subgroup may produce several kinds of specification-related work output:
+- Extensions or amendments to existing specifications (e.g. Wasm core or
+web spec, DWARF, EcmaScript)
+- Creation of new specifications in standards bodies or working
+groups (e.g. Wasm WG, TC39, or future general web-debugging standards working group)
+- Creation of new specifications outside of standards bodies
+(e.g. similar to the LLVM object file format documentation in Wasm tool conventions)
+
+### Non-normative reports
+The Subgroup may produce non-normative material such as requirements
+documents, recommendations, and use cases.
+
+### Software
+The Subgroup may produce software related to Wasm debugging (either as
+standalone tooling or integration of debugging related functionality
+in existing CG software such as Binaryen or WABT). Capabilities may include:
+- Debug info encoding or translation
+- Program instrumentation or analysis
+- Interactive debuggers or profilers
+- Test suites
+
+## Amendments to this Charter and Chair Selection
+
+This charter may be amended, and Subgroup Chairs may be selected by vote of the full
+WebAssembly Community Group.

--- a/subgroups/Debugging.md
+++ b/subgroups/Debugging.md
@@ -3,8 +3,11 @@
 The Debugging Subgroup is a sub-organization of the
 [WebAssembly Community Group](https://www.w3.org/community/webassembly/) of the W3C.
 As such, it is intended that its charter align with that of the CG. In particular, 
-the sections of the CG charter relating to Community and Business Group Process,
-Contribution Mechanics, Transparency, and Decision Process also apply to the Subgroup.
+the sections of the [CG charter](https://webassembly.github.io/cg-charter/) relating to
+[Community and Business Group Process](https://webassembly.github.io/cg-charter/#process),
+[Contribution Mechanics](https://webassembly.github.io/cg-charter/#contrib),
+[Transparency](https://webassembly.github.io/cg-charter/#transparency), and
+[Decision Process](https://webassembly.github.io/cg-charter/#decision) also apply to the Subgroup.
 
 ## Goals
 
@@ -19,11 +22,10 @@ static analysis of WebAssembly programs, including:
 - File formats and encodings for WebAssembly debug information
 e.g. as custom sections in wasm executables or object files, 
 - Extensions to the WebAssembly text format for debug information
-- Extensions or modifications to
-- Interaction with browsers (e.g. developer tools, debugging, profiling)
+- Interaction with browsers or other embedders (e.g. developer tools, debugging, profiling)
 - Interaction with external debuggers and IDEs (VS Code), and
-debuggers running in the browser
-- Presentation of source, callstack, or debugging information in browsers, debuggers,
+debuggers running as wasm-hosted code.
+- Presentation of source, callstack, or debugging information in embedders, debuggers,
 or IDEs
 
 


### PR DESCRIPTION
This is a draft for the charter of the proposed CG subgroup on debugging (discussed in https://github.com/WebAssembly/meetings/blob/master/2018/CG-05-15.md). I intend to discuss it in the next CG meeting (and hopefully poll to create the subgroup) but I put this in the format of a PR to allow easy comments on the content of the charter, so we can discuss it prior to the live meeting. I tried to keep it as general as possible (so we can discuss any relevant debugging-related topic without worrying too much about the process or the charter) while still keeping it subordinate to the CG charter. One tricky piece about that is that there may end up being some debugging-related standard scoped to the web more broadly outside of just wasm, so the wasm subgroup may end up sending recommendations to that rather than the wasm WG if applicable.
But in any case, as far as anyone I talked to knows, subgroups like this are basically unprecedented in the context of W3C groups; so even though everyone is happy with the general idea, there might be feedback on the specifics. So I wanted to get this out for opinions before the meeting.