### PR TITLE
Adjust meeting time for daylight savings time

### DIFF
--- a/2019/WG-03-13.md
+++ b/2019/WG-03-13.md
@@ -3,7 +3,7 @@
 ## Agenda for the March 13 video call of WebAssembly's Working Group
 
 - **Where**: zoom.us
-- **When**: March 13, 2019 at 4pm-5pm UTC *( March 13, 2019 8am-9am PT )*
+- **When**: March 13, 2019 at 3pm-4pm UTC *( March 13, 2019 8am-9am PT )*
 - **Location**: *on calendar invite to registered attendees*
 - **Contact**:
     - Name: Ben Smith


### PR DESCRIPTION
The calendar invite is in Pacific time, so it stayed at 8am, which moves the UTC time back.