### PR TITLE
Add an agenda item for creating a WASI Subgroup.

### DIFF
--- a/2019/CG-04-02.md
+++ b/2019/CG-04-02.md
@@ -33,6 +33,10 @@ Installation is required, see the calendar invite.
       * Replacing Brad Nelson as co-champion with Francis McCabe
       * General questions / discussion?
       * Poll: rename this feature from "Host Bindings" to "Web IDL Bindings" (and thus the repo along with it)
+    4. Discuss starting a new CG Subgroup for WASI
+      * For background, see [the WASI blog post](https://hacks.mozilla.org/2019/03/standardizing-wasi-a-webassembly-system-interface/).
+      * We propose a Subgroup, to iterate on and eventually standardize WASI Core, as well as other modules in the future.
+      * Poll: Create a new Subgroup with this charter (based on the Debugging subgroup's charter): https://github.com/CraneStation/wasmtime-wasi/blob/wasi/docs/WASI-proposed-CG-subgroup-charter.md
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
For background, see [the WASI blog post](https://hacks.mozilla.org/2019/03/standardizing-wasi-a-webassembly-system-interface/).
