### PR TITLE
Add discussion of formatted diff for proposals.

### DIFF
--- a/2019/CG-05-28.md
+++ b/2019/CG-05-28.md
@@ -28,6 +28,7 @@ Installation is required, see the calendar invite.
 1. Adoption of the agenda
 1. Proposals and discussions
     1. Review of action items from prior meeting.
+    1. Should proposals have a formatted diff of changes to the spec?
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
I've recently had some time to look into the existing proposals in more detail. I've been struggling to find all the changes for review/implementation, however. I'd be great if we could have formatted diffs similar to what TC-39 / other W3C specs have in the various proposals' README.md.