### PR TITLE
Add code of conduct mention for June F2F

### DIFF
--- a/2019/CG-06.md
+++ b/2019/CG-06.md
@@ -32,10 +32,11 @@
           15003 A Coruña
           
           ([Google Maps](https://www.google.com/maps/place/Artabria/@43.366403,-8.415427,17z/data=!3m1!4b1!4m5!3m4!1s0xd2e7c61fdf53009:0x267e83aa83e3ea4!8m2!3d43.366403!4d-8.413233))
-
 - **Contact**:
     - info@igalia.com
     - +34981913991
+- **Code of conduct**:
+  (Standard event code of conduct for hosting organization)[https://webengineshackfest.org/2019/#coc]
 
 ### Registration
 
@@ -68,7 +69,7 @@ These are a few suggestions for accommodation including the distances to Igalia 
     1. Opening, welcome and roll call
         1. Opening of the meeting
         1. Introduction of attendees
-        1. Host facilities, local logistics
+        1. Host facilities, local logistics, code of conduct
     1. Find volunteers for note taking
     1. Adoption of the agenda
     1. Proposals and discussions
@@ -85,7 +86,7 @@ These are a few suggestions for accommodation including the distances to Igalia 
     1. Opening, welcome and roll call
         1. Opening of the meeting
         1. Introduction of attendees
-        1. Host facilities, local logistics
+        1. Host facilities, local logistics, code of conduct
     1. Find volunteers for note taking
     1. Adoption of the agenda
     1. Proposals and discussions


### PR DESCRIPTION
This PR adds a link to Igalia's standard events code of conduct for the June meeting.  It happens to link out to a page from a different event but to avoid importing the specific CoC into this repo, and to avoid the question of what the W3C's / WebAssembly CG's official CoC is, this seems like a lightweight solution.

This PR also adds a time in the morning to briefly remind people of the CoC and of host organization contacts for reporting any problem.