### PR TITLE
Update location to 121 Spear St.

### DIFF
--- a/2020/CG-02.md
+++ b/2020/CG-02.md
@@ -21,7 +21,8 @@
     - TBD
 - **Location**:
     - Google SF
-    - 2 Harrison St, San Francisco, CA 94105
+    - 121 Spear St, San Francisco, CA 94105
+    - Guest entry point: Two Rincon Courtyard
 - **Wifi**: TBD
 - **Dinner**:
     - TBD


### PR DESCRIPTION
The location of the meeting is now changed to 121 Spear St., instead of 2 Harrison St., to take into account a larger attendee list as well as the number of external guests. The new location is ~2 blocks away from the previous location.