### PR TITLE
Restore Feb 18th meeting

### DIFF
--- a/2020/CG-02-18.md
+++ b/2020/CG-02-18.md
@@ -1,0 +1,40 @@
+![WebAssembly logo](/images/WebAssembly.png)
+
+## Agenda for the February 18th video call of WebAssembly's Community Group
+
+- **Where**: zoom.us
+- **When**: February 18th, 5pm-6pm UTC (February 18th, 9am-10am Pacific Daylight Time)
+- **Location**: *link on calendar invite*
+
+### Registration
+
+None required if you've attended before. Send an email to the acting [WebAssembly CG chair](mailto:webassembly-cg-chair@chromium.org)
+to sign up if it's your first time. The meeting is open to CG members only.
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+Installation is required, see the calendar invite.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Opening of the meeting
+    1. Introduction of attendees
+1. Find volunteers for note taking (acting chair to volunteer)
+1. Adoption of the agenda
+1. Proposals and discussions
+    1. Review of action items from prior meeting.
+1. Closure
+
+## Agenda items for future meetings
+
+*None*
+
+### Schedule constraints
+
+*None*
+
+## Meeting Notes
+
+To be added after the meeting.


### PR DESCRIPTION
This meeting was previously cancelled, restoring this edition based on requests from attendees at the in-person meeting that want to follow up on overflow items and discussions.