### PR TITLE
Update WG-03-11 for DST

### DIFF
--- a/2020/WG-03-11.md
+++ b/2020/WG-03-11.md
@@ -3,7 +3,7 @@
 ## Agenda for the March 11 video call of WebAssembly's Working Group
 
 - **Where**: zoom.us
-- **When**: March 11, 2020 at 4pm-5pm UTC *( March 11, 2020 8am-9am PT )*
+- **When**: March 11, 2020 at 3pm-4pm UTC *( March 11, 2020 8am-9am PDT )*
 - **Location**: *on calendar invite to registered attendees*
 - **Contact**:
     - Name: Ben Smith


### PR DESCRIPTION
I assume this is pinned to Pacific Time, in which case it's one hour earlier in UTC (and the EU, which will switch to DST 29 March).