### PR TITLE
Add an item for removing the max initial memory restriction in 3/31 CG

### DIFF
--- a/2020/CG-03-31.md
+++ b/2020/CG-03-31.md
@@ -30,6 +30,7 @@ Installation is required, see the calendar invite.
     1. Move [bulk instructions](https://github.com/WebAssembly/bulk-memory-operations) and [reference types](https://github.com/WebAssembly/reference-types) to Phase 4 (Andreas Rossberg)
     1. Move [custom annotations](https://github.com/WebAssembly/annotations) to Phase 3 (Andreas Rossberg)
        - also, discuss Phase 4 criteria, since this does not affect engines
+    1. Discuss [removing the maximum initial memory size restriction](https://github.com/WebAssembly/spec/issues/1116#issuecomment-602589199).
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
See https://github.com/WebAssembly/spec/issues/1116#issuecomment-602589199

Will hopefully be quick as the only objection I am aware of to doing that has changed.