### PR TITLE
Replace link to SIMD issue

### DIFF
--- a/2020/CG-04-28.md
+++ b/2020/CG-04-28.md
@@ -29,7 +29,7 @@ Installation is required, see the calendar invite.
        See https://github.com/WebAssembly/wasm-c-api/issues/132 for background.
        Poll: Should wasm-c-api pursue safety, as discussed in this issue?
        Poll: If not, approve a new WebAssembly C API proposal at phase 0?
-    1. Flexible vectors - [slides](https://github.com/penzn/wasm-long-vectors), product of discussion in [simd/29](https://github.com/WebAssembly/simd/issues/29). Poll: Approve phase 0 for flexible vectors.
+    1. Flexible vectors - [slides](https://github.com/penzn/wasm-long-vectors), [design/1332](https://github.com/WebAssembly/design/issues/1332). Poll: Approve phase 0 for flexible vectors.
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
Fresh issue in WebAssembly/design is a bit more informative that a long conversation on SIMD proposal (it links to the original though).