### PR TITLE
Update CG-04-28.md: Disambiguate Phelps vs Sugarbroad

### DIFF
--- a/2020/CG-04-28.md
+++ b/2020/CG-04-28.md
@@ -264,11 +264,11 @@ KM: Is the reason why this is better... it makes code generation easier, since y
  
 PP: Yeah, generally because you would have to.. We don’t actually combine them 
  
-KM You could do a loop invariant strength reduction, there are loops you can write that you don’t have to flatten it out.. 
+KM: You could do a loop invariant strength reduction, there are loops you can write that you don’t have to flatten it out.. 
  
 AR: Similar concern as KM
  
-JP: Consensus requirements are low: do members believe that the feature is in-scope will be workable.
+JS: Consensus requirements are low: do members believe that the feature is in-scope will be workable.
 
 Conclusion: Unanimous consent for Phase 1, with caveats that there are design concerns that need to be discussed. 
  


### PR DESCRIPTION
I'm usually "JPS" but I feel like "JS" is less visually disruptive.