### PR TITLE
Explicit scheduling requirements for online votes

### DIFF
--- a/process/consensus.md
+++ b/process/consensus.md
@@ -55,7 +55,10 @@ It is critical that work progresses between in-person meetings: agreed-upon
 designs need to move forward, and new ideas need to reach some level of maturity
 before being discussed in-person. To that end, this group can reach consensus
 online, either on GitHub repositories under the WebAssembly organization or in
-official video calls. In the latter case, decisions are recorded in meeting
+official video calls. In the latter case, the consensus vote must be added to
+the agenda at least 24 hours before the video call is scheduled to begin, except
+in the case of general interest votes moving pre-proposals to phase 1, which can
+be added as the discussion proceeds. Consensus decisions are recorded in meeting
 notes and published just like in-person meeting notes are published.
 
 We introduce the following concepts to help the online decision process:


### PR DESCRIPTION
Looking in the process docs, I was unable to find specific wording on
our requirement that votes be explicit in the agenda for online
meetings.

The "In-person meeting consensus" section of consensus.md has the
following paragraph:

> For in-person meetings, champions are expected to list points for
  which they will seek consensus in the meeting agenda, and new
  consensus points can be added in-person as the discussion proceeds.

I propose that we add language to the "Online consensus" section
disallowing consensus votes that were not on the agenda 24 hours
before the meeting (our current practice) and I further propose that
we make an exception for general interest votes on pre-proposals. The
goal of this exception is to eliminate artificial process delays for
moving proposals to phase 1, given that the technical bar for that
move is so low.

If we reach consensus on this change here, I will add an agenda item to
vote on this change at a CG meeting.