### PR TITLE
Add a vote for bulk memory too

### DIFF
--- a/main/2020/CG-06-23.md
+++ b/main/2020/CG-06-23.md
@@ -30,6 +30,8 @@ Installation is required, see the calendar invite.
     1. Advance [reference types](https://github.com/WebAssembly/reference-types/) to phase 4 (Andreas Rossberg)
        1. Poll on removing type annotation on ref.is_null ([issue](https://github.com/WebAssembly/reference-types/issues/99))
        1. Poll on advancing to phase 4
+    1. Advance [bulk memory operations](https://github.com/WebAssembly/bulk-memory-operations/) to phase 4 (Ben Smith)
+       1. Poll on advancing to phase 4
     1. Advance numeric values in data segments proposal ([discussion](https://github.com/WebAssembly/design/issues/1348) and [semi-formal description repo](https://github.com/echamudi/numeric-values-in-data-segments-wasm-proposal))
        1. Poll on general interest in this proposal and advancing to phase 1
 1. Closure


### PR DESCRIPTION
It's blocked only on reftypes, so if reftypes is ready bulk memory should be ready too.