### PR TITLE
Increase time allotted for EH presentation by 5 mins

### DIFF
--- a/main/2020/CG-09-01.md
+++ b/main/2020/CG-09-01.md
@@ -25,7 +25,7 @@ Installation is required, see the calendar invite.
 1. Adoption of the agenda
 1. Proposals and discussions
     1. Review of action items from prior meeting.
-    1. [Proposal for changes in EH proposal for two-phase unwinding support](https://github.com/WebAssembly/exception-handling/issues/123) Part 2 + discussions (Heejin Ahn) [25 min]
+    1. [Proposal for changes in EH proposal for two-phase unwinding support](https://github.com/WebAssembly/exception-handling/issues/123) Part 2 + discussions (Heejin Ahn) [30 min]
        - Potential poll: Should we make the change?
 1. Closure
 


### PR DESCRIPTION
Given that we are likely to have another discussions that spans 30 mins,
increasing this by 5 mins looks OK too.