### PR TITLE
Propose relaxed dead code validation (Phase 1)

### DIFF
--- a/main/2020/CG-09-29.md
+++ b/main/2020/CG-09-29.md
@@ -28,6 +28,7 @@ Installation is required, see the calendar invite.
     1. POLL: [Memory 64 to phase 2](https://github.com/webassembly/memory64) (Ben Smith) [5-10 min]
     1. Presentation and feedback gathering on branch hinting ([issue](https://github.com/WebAssembly/design/issues/1363)) (Yuri Iozzelli) [20 min]
     1. Fix typing of `select` (WebAssembly/reference-types#116) (Andreas Rossberg) [20 min]
+    1. POLL: [Relaxed dead code validation to phase 1](https://github.com/WebAssembly/design/issues/1379) (Conrad Watt and Ross Tate) [5-10 min]
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
Co-champions: @conrad-watt, @RossTate 

This can be bumped to the next meeting if necessary due to timing, but it's highly related to Andreas' `select` typing issue, so I'm hoping to piggy-back on his explanation of the issue (https://github.com/WebAssembly/design/issues/1379). This proposal is for the smaller version of the change described in the linked issue.

My vision would be to have an relatively uncontroversial phase 1 vote this week to create the proposal repo, and then a much longer presentation/discussion next meeting with a possible phase 2 vote (the spec changes are small - we mainly need commitment from implementers on the decode/validation changes to advance further).

Note that it's fine for Andreas' proposed typing change to land first - we're not proposing to make reference types depend on this proposal.