### PR TITLE
Add Common Lisp stack meetings

### DIFF
--- a/stack/2020/SG-12-14.md
+++ b/stack/2020/SG-12-14.md
@@ -3,8 +3,8 @@
 ## Agenda for the November 30th video call of WebAssembly's Stack Subgroup
 
 - **Where**: zoom.us
-- **When**: November 30th, 17:00-18:00 UTC (November 30th, 9am-10am Pacific Standard Time)
-- **Location**: [Zoom call](https://zoom.us/j/91846860726?pwd=NVVNVmpvRVVFQkZTVzZ1dTFEcXgrdz09)
+- **When**: December 14th, 17:00-18:00 UTC (November 30th, 9am-10am Pacific Standard Time)
+- **Location**: TBD
 
 
 ## Participants
@@ -18,7 +18,7 @@
 1. Find volunteers for note taking (acting chair to volunteer)
 1. Adoption of the agenda
 1. Discussions
-   1. Common Lisp Condition System versus exception systems (Michał "phoe" Herda) [35 mins]
+   1. Control Flow in Common Lisp aka Why Lisp Doesn't Need Throwing Exceptions (Michał "phoe" Herda) [35 mins]
    1. Call for presentations [2 mins].
 1. Closure
 

--- a/stack/2020/SG-12-14.md
+++ b/stack/2020/SG-12-14.md
@@ -1,6 +1,6 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the November 30th video call of WebAssembly's Stack Subgroup
+## Agenda for the December 14th video call of WebAssembly's Stack Subgroup
 
 - **Where**: zoom.us
 - **When**: December 14th, 17:00-18:00 UTC (November 30th, 9am-10am Pacific Standard Time)

--- a/stack/2020/SG-12-14.md
+++ b/stack/2020/SG-12-14.md
@@ -3,7 +3,7 @@
 ## Agenda for the December 14th video call of WebAssembly's Stack Subgroup
 
 - **Where**: zoom.us
-- **When**: December 14th, 17:00-18:00 UTC (November 30th, 9am-10am Pacific Standard Time)
+- **When**: December 14th, 17:00-18:00 UTC (December 14th, 9am-10am Pacific Standard Time)
 - **Location**: TBD
 
 


### PR DESCRIPTION
This is related to the mail I've sent to @fgmccabe regarding splitting the already existing meeting invitation into two, due to the amount of material that needs to be discussed and that cannot fit in a single meeting.