### PR TITLE
Add 2020-11-24 meeting agenda and wat-numeric-values phase 2 poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Meeting process is documented:
    * [CG September 29th video call](main/2020/CG-09-29.md)
    * [CG October 13th video call](main/2020/CG-10-13.md)
    * [CG November 10th video call](main/2020/CG-11-10.md)
+   * [CG November 24th video call](main/2020/CG-11-24.md)
 
 </details>
 

--- a/main/2020/CG-11-24.md
+++ b/main/2020/CG-11-24.md
@@ -1,0 +1,41 @@
+![WebAssembly logo](/images/WebAssembly.png)
+
+## Agenda for the November 24th video call of WebAssembly's Community Group
+
+- **Where**: zoom.us
+- **When**: November 24th, 5pm-6pm UTC (November 10th, 9am-10am Pacific Standard Time)
+- **Location**: *link on calendar invite*
+
+### Registration
+
+None required if you've attended before. Send an email to the acting [WebAssembly CG chair](mailto:webassembly-cg-chair@chromium.org)
+to sign up if it's your first time. The meeting is open to CG members only.
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+Installation is required, see the calendar invite.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Opening of the meeting
+    1. Introduction of attendees
+1. Find volunteers for note taking (acting chair to volunteer)
+1. Adoption of the agenda
+1. Proposals and discussions
+    1. Review of action items from prior meeting.
+    1. POLL: Advancing [Numeric Values in WAT Data Segments Proposal](https://github.com/WebAssembly/wat-numeric-values/blob/master/proposals/wat-numeric-values/Overview.md) to Phase 2 (Ezzat Chamudi) [10 min]
+1. Closure
+
+## Agenda items for future meetings
+
+*None*
+
+### Schedule constraints
+
+*None*
+
+## Meeting Notes
+
+Added after meeting.

--- a/main/2020/CG-11-24.md
+++ b/main/2020/CG-11-24.md
@@ -3,7 +3,7 @@
 ## Agenda for the November 24th video call of WebAssembly's Community Group
 
 - **Where**: zoom.us
-- **When**: November 24th, 5pm-6pm UTC (November 10th, 9am-10am Pacific Standard Time)
+- **When**: November 24th, 5pm-6pm UTC (November 24th, 9am-10am Pacific Standard Time)
 - **Location**: *link on calendar invite*
 
 ### Registration


### PR DESCRIPTION
Hello,
As recommended in [this discussion](https://github.com/WebAssembly/wat-numeric-values/issues/2), this pull request adds a poll for advancing [wat-numeric-values](https://github.com/WebAssembly/wat-numeric-values) proposal to phase 2 in the 2020-11-24 CG meeting.
