### PR TITLE
Add Branch Hinting - Poll for Phase 2 to agenda

### DIFF
--- a/main/2021/CG-03-16.md
+++ b/main/2021/CG-03-16.md
@@ -25,6 +25,7 @@ Installation is required, see the calendar invite.
 1. Adoption of the agenda
 1. Proposals and discussions
     1. Review of action items from prior meeting.
+    1. [Branch Hinting](https://github.com/WebAssembly/branch-hinting) - Poll for Phase 2 (Yuri Iozzelli) [5 min]
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
I see that there are already few PRs for agenda items on the next meeting.

This should be short, but if it doesn't fit I can move it to the following meeting.