### PR TITLE
Add Collaborative Garbage Collection to April 13th

### DIFF
--- a/main/2021/CG-04-13.md
+++ b/main/2021/CG-04-13.md
@@ -31,6 +31,7 @@ Installation is required, see the calendar invite.
        1. Provisional vote, next steps
     1. Formalize SIMD subgroup (5 mins) 
        1. Vote to approve Petr Penzin and Zhi An Ng as subgroup chairs
+    1. Presentation+Discussion: Collaborative Garbage Collection, Ross Tate (20-30 min)
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
I believe I've developed (more peer-review pending) a lightweight high-level algorithmic technology that enables independently implemented and asynchronously executing garbage collectors to (indirectly) cross-reference into each other's heaps and still collaboratively collect cycles spanning multiple heaps. Although the technology can integrate with host-managed garbage collection (and so can integrate with a GC proposal), it can be implemented within original core wasm (and so does not depend on a GC proposal). I would like to first present how the technology works and then open to discussion of how such a technology could be utilized in the wasm ecosystem and/or integrated into wasm proposals.