### PR TITLE
Add agenda item relevant for second CM poll 05-25

### DIFF
--- a/main/2021/CG-05-25.md
+++ b/main/2021/CG-05-25.md
@@ -25,6 +25,7 @@ Installation is required, see the calendar invite.
 1. Adoption of the agenda
 1. Proposals and discussions
     1. Review of action items from prior meeting.
+    1. Present [WebAssembly, UTF-8 and Web Platform APIs - Or: Please don't break the Web 🥺](https://youtu.be/IhvwO0zkbXU) (Daniel Wirtz) [15 mins]
     1. Follow-up discussion from the [CG-04-27 presentation](https://docs.google.com/presentation/d/1PSC3Q5oFsJEaYyV5lNJvVgh-SNxhySWUqZ6puyojMi8) and [design/#1415](https://github.com/WebAssembly/design/issues/1415) (20 min)
        1. Poll: Does the proposed direction sound good?
        1. Poll: Should we proceed with the [next steps](https://docs.google.com/presentation/d/1PSC3Q5oFsJEaYyV5lNJvVgh-SNxhySWUqZ6puyojMi8/edit#slide=id.gcd82cd8251_3_6)?

--- a/main/2021/CG-05-25.md
+++ b/main/2021/CG-05-25.md
@@ -25,7 +25,7 @@ Installation is required, see the calendar invite.
 1. Adoption of the agenda
 1. Proposals and discussions
     1. Review of action items from prior meeting.
-    1. Present [WebAssembly, UTF-8 and Web Platform APIs - Or: Please don't break the Web 🥺](https://youtu.be/IhvwO0zkbXU) (Daniel Wirtz) [15 mins]
+    1. Present [WebAssembly, UTF-8 and Web Platform APIs](https://youtu.be/IhvwO0zkbXU) (Daniel Wirtz) [15 mins]
     1. Follow-up discussion from the [CG-04-27 presentation](https://docs.google.com/presentation/d/1PSC3Q5oFsJEaYyV5lNJvVgh-SNxhySWUqZ6puyojMi8) and [design/#1415](https://github.com/WebAssembly/design/issues/1415) (20 min)
        1. Poll: Does the proposed direction sound good?
        1. Poll: Should we proceed with the [next steps](https://docs.google.com/presentation/d/1PSC3Q5oFsJEaYyV5lNJvVgh-SNxhySWUqZ6puyojMi8/edit#slide=id.gcd82cd8251_3_6)?


### PR DESCRIPTION
I have pre-recorded a presentation on why I think that we should not proceed with the next steps as presented in "Scoping and Layering the Module Linking and Interface Types proposals", that I would like to play at a meeting for the necessary context. I am aware that my presentation does not fit into this meeting's time slot anymore, but as it is highly relevant for the poll, it needs to be scheduled before somehow. Please feel free to re-schedule as needed :)