### PR TITLE
Add resizable buffers agenda item

### DIFF
--- a/main/2021/CG-06-22.md
+++ b/main/2021/CG-06-22.md
@@ -27,6 +27,7 @@ Installation is required, see the calendar invite.
     1. Review of action items from prior meeting.
     1. Discussion: [WebAssembly, Unicode and the Web Platform](https://github.com/WebAssembly/design/issues/1419) (pre-recorded, see linked issue; [slides](presentations/2021-06-22-wirtz-webassembly-unicode-web-platform.pdf)) [20 mins]
     1. [Deprecation of cross origin module sharing](https://github.com/WebAssembly/spec/issues/1303) [20 mins]
+    1. [Wasm/JS API integration for resizable buffers](https://github.com/WebAssembly/spec/issues/1292]) (Shu-yu Guo) [20 mins]
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
Resizable buffers reached stage 3, so bringing the integration back to wasm for phase advancement.