### PR TITLE
Create discussions.md for constructive CG discussions

### DIFF
--- a/process/discussion.md
+++ b/process/discussion.md
@@ -1,0 +1,61 @@
+# Constructive CG Discussions
+
+The intent of this document is to encourage positive, and constructive discussions
+in the WebAssembly CG. This document contains a non-exhaustive list of guidelines
+to nudge discussions towards positive outcomes.
+
+## Tone
+
+- **Keep discussions factual and non-judgemental**
+
+- **Avoid passive-aggressive language**  
+  It can be helpful to identify sources of frustration, but it is often best
+  not to post while actively frustrated to avoid letting that frustration turn
+  into passive aggression.
+
+- **Avoid patronizing language**  
+  For example, implying someone is ignorant (e.g. "This is common knowledge in
+  <technical community>; I’m surprised I have to explain this") or feigning ignorance.
+
+- **Avoid asking rhetorical questions**  
+  Phrase questions in a way that advances the discussion. For example,
+  Instead of asking “Have you considered X?” When you know X has not been considered,
+  write up an analysis of X yourself or to ask "What happens when you consider X?"
+
+## Content
+
+- **Acknowledge the validity of different use cases and priorities**  
+  This makes conversations more inclusive and avoids unnecessary arguments about
+  differences in points of view that fundamentally cannot be resolved.
+
+- **Ask clarifying questions**  
+  When someone's comment is unclear, it's better to ask for clarification or
+  confirmation of your understanding than to make assumptions about what they meant.
+
+- **Provide constructive, actionable feedback**  
+  When providing feedback on an idea, avoid broad generalizations, and provide
+  concrete examples where possible.
+
+## Conversation management
+
+- **Take conversations one step at a time**  
+  It can be reasonable to provide a full chain of reasoning in a single comment,
+  but don't ask others to respond to the conclusion without giving them a chance
+  to respond to the steps that led to the conclusion first.
+
+- **Keep conversations focused**  
+  Threads have different purposes such as brainstorming, bikeshedding,
+  consensus seeking, etc. Create new threads for new topics or new purposes
+  of discussion.
+  
+## Conflict resolution
+
+- **Resolution through vote at a meeting**  
+  In case of prolonged disagreement, consider bringing the issue up at a relevant
+  subgroup meeting where applicable, or to the CG meeting so the issue can be
+  put to a vote.
+
+- **Resolution through implementer feedback**  
+  In cases where progress is blocked, and consensus looks unlikely, feedback from
+  compiler, tool, and engine implementers can be a useful resource to
+  provide actionable next steps.


### PR DESCRIPTION
Adding a document with suggestions for constructive CG discussions. This is not specific to meetings, but we don't have a good place to put general process documents, so this seems like a good start.

Thanks @tlively for collaborating on this document.