### PR TITLE
Discussion of Constant-TIme at cg-07-20

### DIFF
--- a/main/2021/CG-07-20.md
+++ b/main/2021/CG-07-20.md
@@ -25,6 +25,8 @@ Installation is required, see the calendar invite.
 1. Adoption of the agenda
 1. Proposals and discussions
     1. Review of action items from prior meeting.
+    1. [Update + Discussion on Constant-Time Proposal](https://github.com/WebAssembly/constant-time) [20 mins]
+        1. Poll for phase 1
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
After speaking with some folks involved, there is consensus that we're ready to present some progress done on the constant-time proposal since our previous presentation in February 2020. We are also interested in polling for phase 1. (The proposal is currently at phase 0)