### PR TITLE
Add relevant items to CG-08-03 string discussion

### DIFF
--- a/main/2021/CG-08-03.md
+++ b/main/2021/CG-08-03.md
@@ -27,7 +27,9 @@ Installation is required, see the calendar invite.
     1. Review of action items from prior meeting.
     1. Update on JS API for Stack Switching (Ross/Luke/Francis) [10 mins]
         1. Poll for phase 1?
-    1. Summary of [interface-types/#135](https://github.com/WebAssembly/interface-types/issues/135) and discussion [30 min].
+    1. Summary of [interface-types/#135](https://github.com/WebAssembly/interface-types/issues/135) and discussion [50 min].
+        1. Poll for supporting [UTF-16](https://github.com/WebAssembly/interface-types/issues/136#issuecomment-861799460) lifting and lowering
+        1. [Summary of concerns](https://github.com/WebAssembly/interface-types/issues/135#issuecomment-888878363) by W/UTF-16 languages
         1. Poll for maintaining single list-of-USV `string` type
 1. Closure
 


### PR DESCRIPTION
It has been suggested to me to increase the time slot allotted for the scheduled string discussion, and I'd like to make use of this suggestion to add relevant votes that I think should be decided before the `string` respectively `char` type is restricted. In particular, there appears to be a general appetite to at least make sure that well-formed UTF-16 is properly supported, while I am personally very interested in hearing opinions on whether the single mechanism being proposed can indeed be considered in-line with Wasm's high-level goals.