### PR TITLE
Move Branch Hinting update to the following meeting

### DIFF
--- a/main/2021/CG-08-03.md
+++ b/main/2021/CG-08-03.md
@@ -25,8 +25,6 @@ Installation is required, see the calendar invite.
 1. Adoption of the agenda
 1. Proposals and discussions
     1. Review of action items from prior meeting.
-    1. Update on [Branch Hinting](https://github.com/WebAssembly/branch-hinting) [20 min].
-        1. Poll for phase 3
     1. Summary of [interface-types/#135](https://github.com/WebAssembly/interface-types/issues/135) and discussion [30 min].
         1. Poll for maintaining single list-of-USV `string` type
 1. Closure

--- a/main/2021/CG-08-17.md
+++ b/main/2021/CG-08-17.md
@@ -25,6 +25,8 @@ Installation is required, see the calendar invite.
 1. Adoption of the agenda
 1. Proposals and discussions
     1. Review of action items from prior meeting.
+    1. Update on [Branch Hinting](https://github.com/WebAssembly/branch-hinting) [20 min].
+        1. Poll for phase 3
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
Given the ongoing discussion in https://github.com/WebAssembly/design/issues/1424 , I think it makes sense to postpone the branch hinting update and phase 3 vote to a following meeting.