### PR TITLE
Update CG-08-17.md branch hinting item

### DIFF
--- a/main/2021/CG-08-17.md
+++ b/main/2021/CG-08-17.md
@@ -25,8 +25,9 @@ Installation is required, see the calendar invite.
 1. Adoption of the agenda
 1. Proposals and discussions
     1. Review of action items from prior meeting.
-    1. Update on [Branch Hinting](https://github.com/WebAssembly/branch-hinting) [20 min].
-        1. Poll for phase 3
+    1. Update on [Branch Hinting](https://github.com/WebAssembly/branch-hinting) [30 min].
+        1. Presentation: a framework for code annotations
+        2. Discussion
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
Given the discussion in https://github.com/WebAssembly/design/issues/1424 , I changed the plan for the agenda item on branch hinting.

I want to present a summary of that discussion and  a draft of a code annotation framework (that branch hinting would use).

Since I would also like to have a discussion about it, I increased the time slot to 30 minutes.
