### PR TITLE
WASI: Add a demo of `async` for 2021-10-07 meeting

### DIFF
--- a/wasi/2021/WASI-10-07.md
+++ b/wasi/2021/WASI-10-07.md
@@ -28,4 +28,5 @@ The meeting will be on a zoom.us video conference.
     1. Pointing out [component-model/#1](https://github.com/WebAssembly/component-model/pull/1) in case WASI folks have feedback (as many participants' use cases have been incorporated).  Discussion during the meeting is also welcome if there is free time.
     3. _Sumbit a PR to add your announcement here_
 1. Proposals and discussions
+    1. Demo of `async` support in `witx-bindgen` (@alexcrichton, 15min)
     1. _Sumbit a PR to add your agenda item here_


### PR DESCRIPTION
This won't be a super involved demo so I don't think it will take too
long, but if there's not much else for the agenda I'm happy to dive into
more details about it as well.