### PR TITLE
edit wasi-data link

### DIFF
--- a/wasi/2021/WASI-07-29.md
+++ b/wasi/2021/WASI-07-29.md
@@ -28,7 +28,7 @@ The meeting will be on a zoom.us video conference.
 1. Announcements
     1. _Sumbit a PR to add your announcement here_
 1. Proposals and discussions
-    1. [WASI data API](https://github.com/singlestore-labs/wasi-data/blob/main/proposals/wasi-data/Explainer.md) - create computational DAG's with WASM modules using map, filter, and join semantics (Bailey Hayes, 20 min, [slides](presentations/2021-07-29-hayes-wasi-data.pdf))
+    1. [WASI data API](https://github.com/singlestore-labs/wasi-data) - create computational DAG's with WASM modules using map, filter, and join semantics (Bailey Hayes, 20 min, [slides](presentations/2021-07-29-hayes-wasi-data.pdf))
     1. [Interface Types Update](https://github.com/WebAssembly/interface-types) - an update on where the interface types proposal is at and how it affects WASI (Alex Crichton, 30 min, [slides](presentations/2021-07-29-alexcrichton-interface-types-and-wasi.pdf))
 
 ## Notes


### PR DESCRIPTION
Forking the wasi repo and including proposal doc buried within docs has been a major stumbling block for contributors. We are going to drop that model for our proposal so that it's easier to collaborate with folks outside the WASM community.