### PR TITLE
Link to GC agenda issues from the GC directory

### DIFF
--- a/gc/README.md
+++ b/gc/README.md
@@ -1,0 +1,1 @@
+Notes for past GC subgroup meetings. Agendas for future meetings are managed as [issues in the GC repo](https://github.com/WebAssembly/gc/issues?q=is%3Aissue+%22Agenda+for+subgroup+meeting%22).


### PR DESCRIPTION
The GC subgroup manages agendas for future meetings via issues in the GC repo rather than via pull requests to this repository. Since this can be a source of confusion, add a note about it here.