### PR TITLE
Add subgroups.md

### DIFF
--- a/process/subgroups.md
+++ b/process/subgroups.md
@@ -14,7 +14,7 @@ To create a subgroup, you should add a poll to a CG meeting agenda with at least
 | GC  | Thomas Lively (@tlively)  | [Repo](https://github.com/WebAssembly/gc)  | [Agendas](https://github.com/WebAssembly/gc/issues?q=is%3Aissue+%22Agenda+for+subgroup+meeting%22)  |
 | SIMD  | Petr Penzin (@penzn), Ng Zhi An (@ngzhian)  | ? | [Agendas](https://github.com/WebAssembly/meetings/tree/main/simd/)  |
 | Stack Switching  | Francis McCabe (@fgmccabe)  | [Repo](https://github.com/WebAssembly/stack-switching)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/stack)  |
-| WASI  | Lin Clark (@linclark), Sam Clegg (@sbc)  | [Repo](https://github.com/WebAssembly/WASI)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/wasi)  |
+| WASI  | Lin Clark (@linclark), Sam Clegg (@sbc100)  | [Repo](https://github.com/WebAssembly/WASI)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/wasi)  |
 
 ## Subgroup Leadership Expectations
 

--- a/process/subgroups.md
+++ b/process/subgroups.md
@@ -5,6 +5,8 @@ Subgroups of the CG are created when one (or both) of the following apply:
 - An area of interest that needs a lot of discussion. Creating a subgroup with regular meetings provides more bandwidth for this discussion.
 - An area of interest is only relevant to a small group of participants. In these cases, subgroup meetings give a more focused venue. This way, participants don’t have concerns about wasting the CG’s time with something that the rest of the CG is not engaged in.
 
+To create a subgroup, you should add a poll to a CG meeting agenda with at least 7 days notice. As part of the poll, you should provide information about who will be chairing the subgroup.
+
 ## Active Subgroups
 
 | Subgroup  | Chair(s)  | Discussion Repo  | Meetings  |

--- a/process/subgroups.md
+++ b/process/subgroups.md
@@ -13,7 +13,7 @@ To create a subgroup, you should add a poll to a CG meeting agenda with at least
 |---|---|---|---|
 | GC  | Thomas Lively (@tlively)  | [Repo](https://github.com/WebAssembly/gc)  | [Agendas](https://github.com/WebAssembly/gc/issues?q=is%3Aissue+%22Agenda+for+subgroup+meeting%22)  |
 | SIMD  | Petr Penzin (@penzn), Ng Zhi An (@ngzhian)  | ? | [Agendas](https://github.com/WebAssembly/meetings/tree/main/simd/)  |
-| Stack  | Francis McCabe (@fgmccabe)  | [Repo](https://github.com/WebAssembly/stack-switching)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/stack)  |
+| Stack Switching  | Francis McCabe (@fgmccabe)  | [Repo](https://github.com/WebAssembly/stack-switching)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/stack)  |
 | WASI  | Lin Clark (@linclark), Sam Clegg (@sbc)  | [Repo](https://github.com/WebAssembly/WASI)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/wasi)  |
 
 ## Subgroup Leadership Expectations

--- a/process/subgroups.md
+++ b/process/subgroups.md
@@ -25,7 +25,7 @@ Subgroups require two kinds of leadership. These roles can be filled by the same
 A subgroup chair is expected to:
 
 - Organize subgroup meetings:
-  - Create agendas in advance so that others can add issues via PRs. These agendas should live in a subgroup-specific folder in the [WebAssembly meetings repo](https://github.com/WebAssembly/meetings). 
+  - Create agendas in advance so that others can add issues via PRs. These agendas should live in a subgroup-specific folder in the [WebAssembly meetings repo](https://github.com/WebAssembly/meetings). Alternatively, agendas can be organized via issues on a proposal repo for subgroups covering just a single proposal.
   
       Each agenda should have a header that includes meeting details and instructions for how to join. See [this agenda](https://github.com/WebAssembly/meetings/blob/main/wasi/2021/WASI-10-07.md) for an example.
   

--- a/process/subgroups.md
+++ b/process/subgroups.md
@@ -9,9 +9,9 @@ Subgroups of the CG are created when one (or both) of the following apply:
 
 | Subgroup  | Chair(s)  | Discussion Repo  | Meetings  |
 |---|---|---|---|
-| GC  | Thomas Lively (@tlively) + others?  | [Repo](https://github.com/WebAssembly/gc)  | [Agendas](https://github.com/WebAssembly/gc/issues?q=is%3Aissue+%22Agenda+for+subgroup+meeting%22)  |
-| SIMD  | Petr Penzin (@penzn) + others?  | ? | [Agendas](https://github.com/WebAssembly/meetings/tree/main/simd/)  |
-| Stack  | Francis McCabe (@fgmccabe) + others?  | [Repo](https://github.com/WebAssembly/stack-switching)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/stack)  |
+| GC  | Thomas Lively (@tlively)  | [Repo](https://github.com/WebAssembly/gc)  | [Agendas](https://github.com/WebAssembly/gc/issues?q=is%3Aissue+%22Agenda+for+subgroup+meeting%22)  |
+| SIMD  | Petr Penzin (@penzn), Ng Zhi An (@ngzhian)  | ? | [Agendas](https://github.com/WebAssembly/meetings/tree/main/simd/)  |
+| Stack  | Francis McCabe (@fgmccabe)  | [Repo](https://github.com/WebAssembly/stack-switching)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/stack)  |
 | WASI  | Lin Clark (@linclark), Sam Clegg (@sbc)  | [Repo](https://github.com/WebAssembly/WASI)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/wasi)  |
 
 ## Subgroup Leadership Expectations

--- a/process/subgroups.md
+++ b/process/subgroups.md
@@ -7,10 +7,11 @@ Subgroups of the CG are created when one (or both) of the following apply:
 
 To create a subgroup, you should add a poll to a CG meeting agenda with at least 7 days notice. As part of the poll, you should provide information about who will be chairing the subgroup.
 
-## Active Subgroups
+## Current Subgroups
 
 | Subgroup  | Chair(s)  | Discussion Repo  | Meetings  |
 |---|---|---|---|
+| Debugging  | Derek Schuff (@dschuff)  | [Repo](https://github.com/WebAssembly/debugging)  | no meetings currently scheduled, but discussion or agenda suggestions are welcome |
 | GC  | Thomas Lively (@tlively)  | [Repo](https://github.com/WebAssembly/gc)  | [Agendas](https://github.com/WebAssembly/gc/issues?q=is%3Aissue+%22Agenda+for+subgroup+meeting%22)  |
 | SIMD  | Petr Penzin (@penzn), Ng Zhi An (@ngzhian)  | ? | [Agendas](https://github.com/WebAssembly/meetings/tree/main/simd/)  |
 | Stack Switching  | Francis McCabe (@fgmccabe)  | [Repo](https://github.com/WebAssembly/stack-switching)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/stack)  |

--- a/process/subgroups.md
+++ b/process/subgroups.md
@@ -1,0 +1,66 @@
+# Subgroups
+
+Subgroups of the CG are created when one (or both) of the following apply:
+
+- An area of interest that needs a lot of discussion. Creating a subgroup with regular meetings provides more bandwidth for this discussion.
+- An area of interest is only relevant to a small group of participants. In these cases, subgroup meetings give a more focused venue. This way, participants don’t have concerns about wasting the CG’s time with something that the rest of the CG is not engaged in.
+
+## Active Subgroups
+
+| Subgroup  | Chair(s)  | Discussion Repo  | Meetings  |
+|---|---|---|---|
+| GC  | Thomas Lively (@tlively) + others?  | [Repo](https://github.com/WebAssembly/gc)  | [Agendas](https://github.com/WebAssembly/gc/issues?q=is%3Aissue+%22Agenda+for+subgroup+meeting%22)  |
+| SIMD  | Petr Penzin (@penzn) + others?  | ? | [Agendas](https://github.com/WebAssembly/meetings/tree/main/simd/)  |
+| Stack  | Francis McCabe (@fgmccabe) + others?  | [Repo](https://github.com/WebAssembly/stack-switching)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/stack)  |
+| WASI  | Lin Clark (@linclark), Sam Clegg (@sbc)  | [Repo](https://github.com/WebAssembly/WASI)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/wasi)  |
+
+## Subgroup Leadership Expectations
+
+Subgroups require two kinds of leadership. These roles can be filled by the same person or multiple people:
+
+- Chair(s)—responsible for running the group
+- Champion(s)—responsible for driving technical progress on proposals
+ 
+### Chair
+A subgroup chair is expected to:
+
+- Organize subgroup meetings:
+  - Create agendas in advance so that others can add issues via PRs. These agendas should live in a subgroup-specific folder in the [WebAssembly meetings repo](https://github.com/WebAssembly/meetings). 
+  
+      Each agenda should have a header that includes meeting details and instructions for how to join. See [this agenda](https://github.com/WebAssembly/meetings/blob/main/wasi/2021/WASI-10-07.md) for an example.
+  
+      Note: If you use a Google form for registrations, ensure that you turn on email notifications:
+      - Go to the "Responses" tab in the editing view
+      - Click the "..." menu button in the top pane
+      - Turn on "Get email notifications for new responses"
+
+  - Add [new participants](https://www.w3.org/community/webassembly/participants) to the Google calendar event. You should ensure the participant is a CG member before adding them by searching for their name in the participant list. If they are not yet listed, explain that registration is free and that they will need to complete that first.
+
+  - While not required, it can be helpful to work 1:1 with champions to ensure they are identifying topics for discussion at meetings and adding them to the agenda.
+
+- Run subgroup meetings:
+
+  - Ensure notes are taken and posted to the meetings repository within one week post-meeting. Public notes are a requirement of the W3C.
+
+  - Facilitate the discussion and step in when disagreements are getting heated or one person is dominating the conversation in an unproductive way.
+
+  - Identify and drive consensus among participants.
+
+  - Identify action items and make note of commitments.
+
+  - Enforce the CoC (see below).
+
+- Maintain the issue queue:
+  - Triage new issues as they come in. This means different things for different proposals, but as the chair, you should keep an eye on issues as they come in and try to ensure that relevant issues are responded to appropriately.
+
+  - Facilitate discussion and identify and drive consensus, as in subgroup meetings.
+
+  - Enforce the CoC (see below).
+
+- Maintain the list of active proposals:
+  - Check in with champions on a quarterly basis to identify the status of the proposal, including any blockers and submit to the CG chairs.
+
+  - Make appropriate updates to the list of active proposals.
+
+- Enforce the code of conduct within the subgroup:
+  - To ensure the safety of the community, we recommend that each subgroup have at least one chair that has completed [Otter Tech’s paid CoC training](https://otter.technology/code-of-conduct-training/) or reviewed the [related documents](https://gitlab.com/otter-tech/coc-incident-response-workshop/-/tree/master). If your organization does not have the funding to pay for this training, contact the CG chairs.

--- a/process/subgroups.md
+++ b/process/subgroups.md
@@ -53,7 +53,7 @@ A subgroup chair is expected to:
   - Enforce the CoC (see below).
 
 - Maintain the issue queue:
-  - Triage new issues as they come in. This means different things for different proposals, but as the chair, you should keep an eye on issues as they come in and try to ensure that relevant issues are responded to appropriately.
+  - Triage new issues as they come in to ensure that relevant issues are responded to appropriately. In subgroups that span multiple proposals, the chair is responsible for triaging group-wide repos, such as the main discussion repo or shared infrastructure repos, while champions are responsible for triaging their own proposal-specific repos.
 
   - Facilitate discussion and identify and drive consensus, as in subgroup meetings.
 

--- a/process/subgroups.md
+++ b/process/subgroups.md
@@ -13,7 +13,7 @@ To create a subgroup, you should add a poll to a CG meeting agenda with at least
 |---|---|---|---|
 | Debugging  | Derek Schuff (@dschuff)  | [Repo](https://github.com/WebAssembly/debugging)  | no meetings currently scheduled, but discussion or agenda suggestions are welcome |
 | GC  | Thomas Lively (@tlively)  | [Repo](https://github.com/WebAssembly/gc)  | [Agendas](https://github.com/WebAssembly/gc/issues?q=is%3Aissue+%22Agenda+for+subgroup+meeting%22)  |
-| SIMD  | Petr Penzin (@penzn), Ng Zhi An (@ngzhian)  | ? | [Agendas](https://github.com/WebAssembly/meetings/tree/main/simd/)  |
+| SIMD  | Petr Penzin (@penzn), Ng Zhi An (@ngzhian)  | [Relaxed SIMD](https://github.com/WebAssembly/relaxed-simd) + [Flexible Vectors](https://github.com/WebAssembly/flexible-vectors/issues) | [Agendas](https://github.com/WebAssembly/flexible-vectors/issues)  |
 | Stack Switching  | Francis McCabe (@fgmccabe)  | [Repo](https://github.com/WebAssembly/stack-switching)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/stack)  |
 | WASI  | Lin Clark (@linclark), Sam Clegg (@sbc100)  | [Repo](https://github.com/WebAssembly/WASI)  | [Agendas](https://github.com/WebAssembly/meetings/tree/main/wasi)  |
 


### PR DESCRIPTION
We currently don't have a document that outlines the responsibilities of subgroup chairs, which makes it harder to onboard new people into the role. 

This is a first stab at that documentation, based on my own experience onboarding + input from the CG chairs and other SG chairs.

## Open issues

- I didn't include the debugging subgroup since it looks like the last meeting was in 2020, but lmk if I should add it.
- I don't know whether I got the chairs right for all the groups
- It does not include responsibilities for champions, but if someone who has played that role wants to fill in, have at it :)