### PR TITLE
Discuss: It's hard to contribute on proposals.

### DIFF
--- a/wasi/2022/WASI-02-10.md
+++ b/wasi/2022/WASI-02-10.md
@@ -28,4 +28,5 @@ The meeting will be on a zoom.us video conference.
     1. _Sumbit a PR to add your announcement here_
 1. Proposals and discussions
     1. Discuss network APIs split. [PR](https://github.com/WebAssembly/WASI/pull/461) - Dave Bakker (@badeend)
-    1. _Sumbit a PR to add your agenda item here_
+    2. It's hard to contribute on proposals. [PR](https://github.com/WebAssembly/WASI/pull/xxx) - Chris Suszynski (@cardil)
+    3. _Sumbit a PR to add your agenda item here_


### PR DESCRIPTION
I find it difficult to contribute to existing proposals. They are a forked WASI repos with additional files.

There's no space for discussion on them, other than creating a PR that targets the fork. I'd like to have a space to discuss first (Github discussions, maybe?!?). Even, opening an PR is hard as it may interfere with the main maintainer commits.

I think the better might be to commit (by PR) a stub of a proposal first. So, then multiple people could provide parts of the proposal in smaller chunks.