### PR TITLE
Typo in link to CG-03-01.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Meeting process is documented:
    * [CG January 18th video call](main/2022/CG-01-18.md)
    * [CG February 1st video call](main/2022/CG-02-01.md)
    * [CG February 15th video call](main/2022/CG-02-15.md)
-   * [CG March 1st video call](main/2021/CG-03-01.md)
+   * [CG March 1st video call](main/2022/CG-03-01.md)
    * [CG March 15th video call](main/2021/CG-03-15.md)
    * [CG March 29th video call](main/2022/CG-03-29.md)
 


### PR DESCRIPTION
The year in the link was 2021 instead of 2022