### PR TITLE
Add agenda item: ES Module Integration update

### DIFF
--- a/main/2022/CG-03-01.md
+++ b/main/2022/CG-03-01.md
@@ -25,6 +25,7 @@ Installation is required, see the calendar invite.
 1. Adoption of the agenda
 1. Proposals and discussions
     1. Update on [Branch Hinting](https://github.com/WebAssembly/branch-hinting) (Yuri Iozzelli) [20 min] 
+    1. Update on [ES Module Integration](https://github.com/WebAssembly/esm-integration) (Asumu Takikawa) [30 min]
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
I'd like to propose an agenda item for the Mar 1 CG meeting about ES module integration. It's close to having one implementation and tests (the phase 3 requirements), so I wanted to provide a progress update and check in how people feel about phase 3.