### PR TITLE
Add poll for moving gc-js-customization to phase 1

### DIFF
--- a/main/2022/CG-03-15.md
+++ b/main/2022/CG-03-15.md
@@ -26,6 +26,7 @@ Installation is required, see the calendar invite.
 1. Proposals and discussions
     1. Update on [Extended Const Expressions](https://github.com/WebAssembly/extended-const) (Sam Clegg) [10 min]
         1. Poll to Phase 2 or Phase 3
+    1. Phase 1 poll for a split-off WasmGC JS Customization proposal (Thomas Lively) [5 min]
     1. Discussion on [Feature Detection](https://github.com/WebAssembly/feature-detection/blob/main/proposals/feature-detection/Overview.md) (Thomas Lively) [45 min]
         1. [How should features be specified?](https://github.com/WebAssembly/feature-detection/issues/3)
         1. [What features should be specified?](https://github.com/WebAssembly/feature-detection/issues/4)


### PR DESCRIPTION
The GC subgroup decided to split off the ability to customize GC objects with custom JS accessors and prototypes into a separate post-MVP proposal. This should be a quick agenda item to vote that new proposal to phase 1.