### PR TITLE
GC Agenda for May 5

### DIFF
--- a/gc/2022/GC-05-03.md
+++ b/gc/2022/GC-05-03.md
@@ -25,7 +25,9 @@ Installation is required, see the calendar invite.
 1. Find volunteers for note taking (acting chair to volunteer)
 1. Adoption of the agenda
 1. Proposals and discussions
-    1. _add agenda items here_
+    1. Discussion: Bringing back `nullref` [#288](https://github.com/WebAssembly/gc/issues/288) [10 minutes]
+    2. Discussion: RTTs [#275](https://github.com/WebAssembly/gc/issues/275) [25 minutes]
+    2. Discussion: Cast opcode refactoring [#274](https://github.com/WebAssembly/gc/issues/274) [25 minutes]
 1. Closure
 
 ## Meeting Notes

--- a/gc/2022/GC-05-17.md
+++ b/gc/2022/GC-05-17.md
@@ -25,8 +25,7 @@ Installation is required, see the calendar invite.
 1. Find volunteers for note taking (acting chair to volunteer)
 1. Adoption of the agenda
 1. Proposals and discussions
-    1. Discussion: Bringing back `nullref` [#288](https://github.com/WebAssembly/gc/issues/288) [15 minutes]
-    2. Discussion: Cast opcode refactoring [#274](https://github.com/WebAssembly/gc/issues/274) [30 minutes]
+    1. _add agenda items here_
 1. Closure
 
 ## Meeting Notes


### PR DESCRIPTION
Move the two agenda items meant for April 19 (incorrectly placed on the May 17
agenda) back to May 3 due to the Easter holiday during the week of April 19.
Also add an additional agenda item to discuss RTTs again.