### PR TITLE
Add stringrefs to GC subgroup agenda, 19 April 2022

### DIFF
--- a/gc/2022/GC-04-19.md
+++ b/gc/2022/GC-04-19.md
@@ -25,6 +25,7 @@ Installation is required, see the calendar invite.
 1. Find volunteers for note taking (acting chair to volunteer)
 1. Adoption of the agenda
 1. Proposals and discussions
+    1. Discussion: [stringrefs](https://github.com/wingo/stringrefs) [20 minutes]
     1. _add agenda items here_
 1. Closure
 


### PR DESCRIPTION
The [stringrefs proposal](https://github.com/wingo/stringrefs/) defines a facility for representing strings.  I plan on proposing it for phase 0 in the CG meeting on 26 April.  Though it doesn't explicitly depend on the GC proposal, it is in the same family, so I thought a brief intro to the GC group might be useful.