### PR TITLE
Add stringrefs to CG agenda, 26 April 2022

### DIFF
--- a/main/2022/CG-04-26.md
+++ b/main/2022/CG-04-26.md
@@ -24,6 +24,8 @@ Installation is required, see the calendar invite.
 1. Find volunteers for note taking (acting chair to volunteer)
 1. Adoption of the agenda
 1. Proposals and discussions
+    1. Initial proposal for [stringrefs](https://github.com/wingo/stringrefs) (Andy Wingo) [15 min]
+        1. Possible poll to phase 1
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
The [stringrefs proposal](https://github.com/wingo/stringrefs) defines a facility for representing reference-typed strings.  I've been gathering early feedback and working on it off and on for some months now.  I would appreciate any feedback from the CG.

As regards polls, I had planned on going to phase 0, but I see that is effectively already done.  Depending on the interest and feedback, it might be appropriate to poll for phase 1 already.