### PR TITLE
Add agenda item to discuss spec versioning

### DIFF
--- a/main/2022/CG-05-10.md
+++ b/main/2022/CG-05-10.md
@@ -26,7 +26,7 @@ Installation is required, see the calendar invite.
 1. Proposals and discussions
     1. Update on [Memory64](https://github.com/WebAssembly/memory64/) (Sam Clegg) [10 min]
     1. Wasm WG followup on Spec versions, see relevant [WG meeting notes](https://github.com/WebAssembly/meetings/blob/main/main/2022/WG-04-13.md) [15 mins]  
-        a. Poll: Adopt new versioning scheme to bump minor version after each stage 5 feature  
+        1. Poll: Adopt new versioning scheme to bump minor version after each stage 5 feature  
 1. Closure
 
 ## Agenda items for future meetings

--- a/main/2022/CG-05-10.md
+++ b/main/2022/CG-05-10.md
@@ -25,6 +25,8 @@ Installation is required, see the calendar invite.
 1. Adoption of the agenda
 1. Proposals and discussions
     1. Update on [Memory64](https://github.com/WebAssembly/memory64/) (Sam Clegg) [10 min]
+    1. Wasm WG followup on Spec versions, see relevant [WG meeting notes](https://github.com/WebAssembly/meetings/blob/main/main/2022/WG-04-13.md) [15 mins]  
+        a. Poll: Adopt new versioning scheme to bump minor version after each stage 5 feature  
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
Agenda item to discuss Wasm spec versioning, specifically:

- Switch to evergreen
- Poll on the versioning strategy going forward

A follow up discussion to address some of the concerns in https://github.com/WebAssembly/design/issues/1395, and to provide better visibility into the WG discussion. 
