### PR TITLE
Add champion.md

### DIFF
--- a/process/champion.md
+++ b/process/champion.md
@@ -1,0 +1,37 @@
+# Responsibilities of a Champion
+
+Champions are authors and editors of proposals. The champion is responsible for
+the evolution of the proposal from Phase 0 through Phase 5, at which point
+maintenance transfers to the WebAssembly Working Group (WG). Champions have
+admin permissions in the proposal repository. Periodically, champions may bring
+their proposal to the [Community Group (CG)
+meetings](https://github.com/WebAssembly/meetings/) to ask for consensus on
+stage advancement.
+
+When asking for advancement, the champion is expected to make the whole
+proposal accessible for review by the CG, by explaining its contents, providing
+supporting documentation, etc. Material changes should be presented explicitly.
+
+It is often beneficial for champions to keep the CG updated with periodic
+status updates outlining major changes in the regular [CG
+meetings](https://github.com/WebAssembly/meetings/). While minor changes can be
+made through discussions within the repository or the relevant subgroup,
+substantial design changes may require a vote from the CG so that the CG has a
+chance to review the proposal and possibly re-evaluate if the proposal is in
+the appropriate stage. Examples include a change to the fundamental assumption
+or structure of a proposal, a decision that has a substantial impact on the
+future direction, or a resolution to a contentious issue that is hard to be
+resolved.
+
+It is not necessary that champions are knowledgeable about every component of
+the spec or its implementation, but they are responsible for the general
+management of the proposal repository, which includes:
+- Keeping track of issues in the proposal repository and mediating them when
+  necessary. When discussions are contentious and hard to resolve, champions
+  are expected to wrap them up and suggest the next steps.
+- Responding to issues or PRs in the repository, or letting other people with
+  expertise take care of them, ensuring that all important issues are
+  appropriately addressed.
+
+Note: First two paragraphs are adapted from the “Scope of Responsibility for
+Champions” section in https://tc39.es/process-document/.


### PR DESCRIPTION
This adds a draft for the doc that describes responsibilities of a
proposal champion. This may have some overlap with that of subgroup
chairs, which we may discuss.