### PR TITLE
Fix June 21 meeting link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Meeting process is documented:
    * [CG May 10th video call](main/2022/CG-05-10.md)
    * [CG May 24th video call](main/2022/CG-05-24.md)
    * [CG June 7th video call](main/2022/CG-06-07.md)
-   * [CG June 14th video call](main/2022/CG-06-14.md)
+   * [CG June 21st video call](main/2022/CG-06-21.md)
    * [CG July 5th video call](main/2022/CG-07-05.md)
    * [CG July 19th video call](main/2022/CG-07-19.md)
    * [CG August 2nd video call](main/2022/CG-08-02.md)


### PR DESCRIPTION
There's currently a broken June 14 link on the main page, but I believe it was meant to point to the June 21st meeting for tomorrow.