### PR TITLE
Schedule funcref adjacent to GC

### DIFF
--- a/main/2022/CG-10.md
+++ b/main/2022/CG-10.md
@@ -53,14 +53,14 @@
  ### Items to be assigned slots
  
  #### Wednesday
+ - Function references update + phase 4 poll
+   - 30 mins (Andreas Rossberg)
  - GC proposal update + phase 3 poll (schedule morning)
    - 45 mins (Thomas Lively + Jakob Kummerow)
  - JS Promise Integration
    - 30 mins (Francis McCabe)
  - Threads update + phase 3 poll
    - 30 mins (Conrad Watt)
- - Function references update + phase 4 poll
-   - 30 mins (Andreas Rossberg)
  - Relaxed SIMD + phase 4 poll(?)
    - 30 mins (Ng Zhi An)
   


### PR DESCRIPTION
Since the former is a dependency for the latter, polling on GC makes little sense before we have polled on funcrefs (for at least phase 3).