### PR TITLE
Add an a WASI meeting agenda item to discuss `_initialize`.

### DIFF
--- a/wasi/2022/WASI-10-20.md
+++ b/wasi/2022/WASI-10-20.md
@@ -28,3 +28,5 @@ The meeting will be on a zoom.us video conference.
     1. _Sumbit a PR to add your announcement here_
 1. Proposals and discussions
     1. WASI certification tests - Marcin Kolny
+    1. Removing `_initialize` from the reactor definition - Dan Gohman
+       1. https://github.com/WebAssembly/WASI/pull/497


### PR DESCRIPTION
Add an agenda item to the WASI-10-20 meeting for a brief presentation of WebAssembly/WASI#497, which removes the `_initialize` function from the description of a reactor.