### PR TITLE
Add Memory64, Extended const updates + agenda shuffle

### DIFF
--- a/main/2022/CG-10.md
+++ b/main/2022/CG-10.md
@@ -65,19 +65,26 @@
  - Threads update + phase 3 poll
    - 30 mins (Conrad Watt)
  - Relaxed SIMD + phase 4 poll(?)
-   - 30 mins (Ng Zhi An)
+   - 45 mins (Ng Zhi An)
+ - Component Model progress update
+   - 30 min pres + 30 min discussion (Luke Wagner)
  - Staged compilation and module linking (optional, if there's time)
    - 30 min (Andreas Rossberg)
   
  #### Thursday
- - Fiber switching
-   - 30 mins (Francis McCabe) (schedule Thu morning)
- - Typed stack switching update
-   - 60 mins (Sam Lindley, Andreas Rossberg) (schedule Thu morning)
- - Stack switching in Wasmtime
-   - 30 mins (Daniel Hillerström) (schedule Thu morning)
- - Component Model progress update
-   - 30 min pres + 30 min discussion (Luke Wagner)
+ - Stack switching discussion:
+   - Fiber switching
+     - 30 mins (Francis McCabe) (schedule Thu morning)
+   - Typed stack switching update
+     - 60 mins (Sam Lindley, Andreas Rossberg) (schedule Thu morning)
+   - Open discussion
+     - 45 mins  
+   - Stack switching in Wasmtime (tentatively moved to research day)
+     - 30 mins (Daniel Hillerström) (schedule Thu morning)
+ - Extended Constant Expressions + poll for Phase 4
+   - 15 mins (Sam Clegg)
+ - Memory64 update
+   - 30 mins (Sam Clegg)
  - WebAssembly roadmap
    - 45 mins round table/panel
 

--- a/main/2022/CG-10.md
+++ b/main/2022/CG-10.md
@@ -79,14 +79,12 @@
      - 60 mins (Sam Lindley, Andreas Rossberg) (schedule Thu morning)
    - Open discussion
      - 45 mins  
-   - Stack switching in Wasmtime (tentatively moved to research day)
-     - 30 mins (Daniel Hillerström) (schedule Thu morning)
  - Extended Constant Expressions + poll for Phase 4
    - 15 mins (Sam Clegg)
  - Memory64 update
    - 30 mins (Sam Clegg)
  - WebAssembly roadmap
-   - 45 mins round table/panel
+   - 45 mins round table/panel (Ben Titzer)
 
 -----
 


### PR DESCRIPTION
Updates:
- Added items for Memory64, extended const @sbc100
- Moved Component Model update to Wednesday, @lukewagner does this time slot work?
-  Adding some buffer time for relaxed-simd for the recent non-determinism discussion @ngzhian 