### PR TITLE
Add meeting notes for 10/2 CG meeting

### DIFF
--- a/main/2022/CG-10.md
+++ b/main/2022/CG-10.md
@@ -1075,7 +1075,7 @@ CW: we have to make sure all those places have a bit free; just in globals isnâ€
 
 #### Type Reflection for WebAssembly JavaScript API + Phase 3 poll (tentative)
 
-IR presenting slides <TODO IR to add link to slides>
+IR presenting [slides](https://docs.google.com/presentation/d/1B7CB_Ko0j2s6vRJ1_zviy73M0win5byTookxC269Go0/edit?resourcekey=0-7Faw71UlKok2U066ruJK2Q#slide=id.p)
 
 IR: one motivation is for mocking imports, another is to use Wasm functions as a subtype of JS functions; allows setting JS functions in Wasm tables. Implemented in browsers, missing spec text.
 

--- a/main/2022/CG-10.md
+++ b/main/2022/CG-10.md
@@ -113,4 +113,1889 @@
 
 ## Meeting notes
 
-To be added after the meeting.
+### Attendees
+In-person:
+ - Ryan Hunt
+ - Steven DeTar
+ - Francis McCabe
+ - Adam Klein
+ - Andrew Brown
+ - Sam Clegg
+ - Brenden Dahl
+ - Arjun Ramesh
+ - Tianshu Huang
+ - Yuri Delendik
+ - Luke Wagner
+ - Chris Fallin
+ - Ben Titzer
+ - Yuri Iozzelli
+ - Ashley Nelson
+ - Heejin Ahn
+ - Ilya Rezvov
+ - Petr Penzin
+ - Daniel Hillerstorm
+ - Conrad Watt
+ - Zhi An Ng
+ - Marat Dhukan
+ - Dan Gohman
+ - Daniel Lopez Ridruejo
+ - Rafael Fernández López 
+ - Arjun Guha
+ - Deepti Gandluri
+ - Luna Phipps-Costin
+ - Derek Schuff
+ - Thomas Lively
+ - Andreas Rossberg
+ - Nabeel Al-Shamma
+ - Shu Yu Guo
+ - Tim Chevalier
+ - Keith Winstein
+
+Virtual Attendees:
+ - Adrian Cole
+ - Angad Kumar Gupta
+ - Alon Zakai
+ - Alex Crichton
+ - Arne Vogel
+ - Asumu Takikawa
+ - Chris Woods
+ - Hannes Payer
+ - Ioanna Dimitriou
+ - Jakob Kummerow
+ - Jeff Charles
+ - Johnnie Birch
+ - Kevin Moore
+ - Lucy Menon
+ - Marco Vassena
+ - Mingqiu Sun
+ - Peter Heune
+ - Rainy Sinclair
+ - Richard Winterton
+ - Ross Tate
+ - Sachin D Agrawal
+ - Sam Lindley
+ - Saul Cabrera
+ - Shravan Narayan
+ - Svyatoslav Kuzmich
+ - Thomas Trankler
+ - Wenwen Wang
+ - Zalim Bashorov
+ - Sergey Rubanov
+
+### Day 1 Discussions
+
+#### Function references update + phase 4 poll
+
+AR Presenting [slides](main/2022/presentations/2022-10-26-rossberg-func-ref-type.pdf)
+
+AR: Will rush through most of this because I assume people are familiar, it’s just my old slides.
+The idea is that we’re going to add a new form of reference type or generalize to this reference type. It’s either a function, an extern, or a concrete type that we can reference now. Optionally these things can be marked as nullable. 
+
+AR: The pre-existing types that we had before are just shorthands. This adds a very specific type of subtyping. A non-nullable type is a subtype of a nullable one, you know its not null.
+
+AR: Concrete types are subtypes of the abstract func.
+
+AR: There are null references and then a bunch of canonical instructions to go with that. And for function references, we find one of the existing instructions, create a function reference. This used to return just a func ref but now returns a type.
+
+AR: Call_ref now allows you to call the reference directly. Now we have concrete types which allow you to call directly. Nice replacement for call_indirect in many places.
+
+AR: Recent Resolutions -> things that happened since last time we presented is that we found a way to deal with the one issue which is what to do about defaultability. Locals and tables rely on default initialization. This is no longer the case under this proposal because we now have nullable references which have no default values.
+
+AR: So what to do about that? There was a long decision about locals. So we settled on having the type check whether the variable is set.
+
+AR: Locals with non-defaultable type start as unset. Local.set marks the variable as set. End of block resets to status quo ante
+
+AR: There are ways to refine this, but this is a conservative choice that could be extended in the future.
+
+AR: For tables, you can add a default initialization value there. You can pre-initialize all the table references or leave it blank.
+
+AR: And that’s all that happened over the last year. Wrote up the specification, done ready, reference interpreter, and test suite are ready. Implemented in V8, SM, Wasmtime. Phase 2, 20201/10/26, no open issues or PRs). At phase 2 for one year
+
+AR: The JS API spec has no owner. At phase 2 for one year. Meets all the requirements for phase 3 and this is a prerequisite for GC stack switching
+
+AR: I argue call_ref is independently useful.
+
+AR: All I wanted to say. Poll for moving to phase 3:
+
+RH: SpiderMonkey implements most of the proposal, but not the table default values or the JS API (which isn’t yet specified).
+
+RT: I don't think this blocks phase 3, but there were some issues found with the performance of wasm calls. Is call_ref improving the performance, can you say more about call performance?
+
+AR: Well, that depends on what the engine does, right? So essentially like, in an engine like wasn't time, for example, it should really be what you expect. It's an indirect call through a pointer in JavaScript engines. You can implement it that way as well, but then, you have to factor some things differently than what some of them do. So you basically have to normalize your function representation so that they are all webassembly functions, all the function references, the other way to do it is that you don't normalize. And then you have to basically do a switch at the callsite, right? Which is, I think, what V8 does. And one reason why it's fairly slow in V8 right now. I don't think that's the best implementation strategy,…
+
+RT: SM is the one that had the best performance because it does the other way. Are you saying call_ref doesn’t really improve performance for the engines that already have good performance?
+
+RH: So, I can speak to call ref and Spider Monkey right now. On the JS boundary when a funcref goes across we do have to have a check that is a webassembly exported function. But in our representation of webassembly exported function, it's a jsobject and in one of the slots on it is the actual entry point to the function. So this is all just internal. Basically our call ref is a load from an object to get the entry point and then it's an indirect call into it. And then we also have to manage cross instance calls, because the call may be to another instance. And so right now, what we do on the caller side, is that we branch on whether it's a cross instance call because we can compare our current instance pointer with the instance that we're going to. And if it's cross instance, we'll do some switching of context and then we'll do the actual indirect call. If it is the same instance, we just do the indirect call and it's pretty fast. So it's basically the same implementation that we have for the actual webassembly call indirect instruction, except we don't have to do the bounds check on the table, and we don't have to load from the table, so they're fairly similar. And the type check, of course.
+
+RT: so youre saying that the type doesn't really give you an advantage. Why is there no call_ref_indirect then?
+
+RH: there’s no downcast in this case, no type check. Not sure I’m understanding?
+
+RT:  So, my understanding of how Spider Monkey works, is it only does that when the call is made on the callee side, you do the check that it's the expectation.
+
+RH: So we have two entry points on functions one for like the WebAssembly call indirect, and that's where we have the callee side signature. One check with callee ref, and one where we're able to skip that and go right into the actual normal direct entry. If we have downcast of functions in the future, that sequence would look for a function ref and would be doing a downcast, which we'll have to implement the actual type, check for that and then a call which will then go to the direct entry. So yeah, it would be different but that's how it's currently implemented right now.
+
+RT: does that give better perf then?
+
+RH: hard to say, we don’t have a lot of code using it yet, just some microbenchmarks.
+
+RT: in our system we explored that and found there wasn’t really any performance improvement, so the check didn’t really cost anything, so creating this extra thing isn’t necessary. So I'm not sure the typed reference is useful.
+
+BT: for GC we may add function subtyping that requires a subtype check, which would mean a greater difference between call and call_indirect.
+
+RT: in our system we also had subtyping and wasn’t an issue. So again, not a blocker for phase 3 but it still seems unclear that this is going to be valuable for engines that already have good performance.
+
+**Poll:** Typed Function references to Phase 3
+
+|SF|F|N|A|SA|
+|--|-|-|-|--|
+|18|20|0|0|0|
+
+#### GC proposal update + phase 3 poll (schedule morning)
+
+TL Presenting [slides](https://docs.google.com/presentation/d/1jLzpH3NZMc_jZwCXscu32kXVA4b5r4gdAlY1vjllEeY/edit?usp=sharing)
+
+TL: Thanks for being here everyone, online and in person. I’d like to give a status update/progress report on the Wasm GC proposal. We’ve been hard at work on it all year long and we think it’s ready for phase 3. Just a brief recap, for folks who haven't been following closely.
+
+TL: What is Wasm GC? The goal is to add GC support to wasm so that wasm modules can interoperate with the host GC. So in a web environment, we want 
+
+TL: How do we do this? We add support for a bunch of types in wasm, user defined structs and array types. These types describe managed data that is visible to the host GC and the host GC knows how to mark them and collect them. So the host GC itself is not part of the proposal because it’s not observable. We have an isorecursive type system to support recursive types. And we introduced instructions for allocating, reading, modifying and downcasting GC data.
+
+TL: The proposal here is really just a MVP for what’s possible in the GC space.
+
+TL: Over the past year, during phase 2, first we added bulk array creation instructions, pretty simple, a bunch of ways to create arrays from new data segments, element segments, and a new easy to create an array fixed on the stack. So I can define a global array and if I want it to have 5 different numbers in it, then I add my 5x i32 consts.
+
+TL: Also added uniformly nullable type shorthands. i32ref and dataref are now nullable.
+
+TL: As Andreas described in the last presentation, we made non-defaultable locals work. That took 438 GitHub discussions.
+
+TL: One of the biggest changes we had is that we deferred Runtime Type Info to post-MVP. Internally, every struct and array value has to have a reference to some type of runtime type information. And this runtime type information is used in downcasts. So if I have a struct and want to check what type it is, I need to check something in the runtime to check what type it is.
+
+TL: Previously these RTT values were explicit in the language. You could create them, pass them to functions. They were required arguments to all the struct creation. However these type annotations were redundant with the type annotations on the values passed into the struct. 
+
+RT: was there a performance reason to remove them?
+
+TL: there was definitely a code size reason, not sure about performance.
+
+RT: : I mean, getting rid of them meant that the casts were much easier to optimize because you could guarantee that they would work in many cases.
+
+TL: well there was a case where some Binaryen optimizations were inhibited where there wasn’t exact correspondence between RTT and static type, it got kind of subtle and complicated
+
+Speaking of those type immediate instructions, we decided to keep type annotations on struct and array accessors.
+
+Added annotations to call_ref. This is slightly redundant because we know that the foo is on the stack. However, there is concern that in the future, we may want to extend the type system in some way such that what is on the stack does not have enough information to tell us that it’s a foo. So it was deemed the most conservative option to keep these type immediates/type annotations. So struct.get/array.get all have these type immediates.
+
+This is a good result for very simple interpreters.
+
+So to match, we decided to add similar type annotations to call_ref since call_ref is basically an accessor for a call ref function type.
+
+
+TL: Func and extern are completely separate types. Any is the supertype internally of all type references.
+
+There is still a conversion type to move between extern and func.
+
+We refactored the cast, they were complicated to use because in order to do a downcast to a ref on a struct or an array, you first had to get it as a data. SO we had this built-in data type. So you had to have two hops, data first, and then downcast from there. We simplified this, unifying the cast infrastructure so you can directly cast from the types at the top of the hierarchy to the ones below. 
+
+We also decided to replace the data built-in type with a struct data-type which is the supertype of all structs.
+
+i31 we talked about removing it and then we didn’t. Didn't know about OCAML folks, they said they're using it so we kept it.
+
+BT: to clarify the type immediates, it wasnt just for the interpreter, but for all tools that process code, its nice to see what types are being manipulated in the code
+
+SC: What were those null modifiers on the cast instructions? 
+
+TL: each one has the null version and if present, the cast will succeed if given a null. Sometimes you want that to succeed and sometimes not, so you can choose.
+
+so each one of these optionally has the NULL version and if null is present, that means that the cast will succeed. Sometimes I want that to succeed. Sometimes I want that to fail. So we have two different versions of the instruction. One that'll succeed, and one that'll fail. So, each toolchain can choose for itself.
+
+SC: failing means trapping in the cast instruction? 
+
+TL: yes, with cast, it traps, with test it returns 0 and with branch you just don’t branch.
+
+Implementation and performance (JK Presenting same slides)
+JK: Implementations are pretty far along. Have been complete for a while. It's more question of keeping up to date with the evolving proposal. V8 and binaryen almost caught up with the current proposal. spidermonkey working on imp. in the very beginning there was no binary definition. For logistical reasons, we're keeping a separate spec document where we describe what the various products do and this is mostly a historical artifact. For example, in the very beginning when we started, there was no binary specification yet of the wire format. And so we just had to make one up. These days, we're almost identical to the upstream proposal. I think the biggest difference is that, we allow two things that the upstream proposal doesn't have yet where we still have to decide to either make them part of the proposal or drop them. One is an array.copy instruction and the other is the area initialization from data, from an element segment that was mentioned. Before we already allow that as a constant instruction, which the official proposal does not allow yet because there is a section ordering problem that we don't have a final answer for yet 
+
+RH: I can share the update on spidermonkey. We’re targeting a combination of the upstream spec and the V8 snapshot, to go where we think it’s heading. And right now we have an implementation in our baseline compiler. And we're starting to work on optimizing tier as well. 2 weeks ago We got a bunch of dart examples of working specifically the barista three benchmark, but lots of PRs in progress, and outstanding for reviews. Still missing generalized casting, i31ref, and downcasting function types. Good progress but not there yet. Also haven’t done much performance optimization. I have heard that Igalia is working on an implementation webkit.
+
+AT: yes, Igalia is working on JSC in collaboration with upstream. We are also tracking the upstream spec and working on the implementation. We have recursive types and subtyping, working on finishing things like the casting semantics. A little behind the others but we expect to have the features working in the next few months and working on optimization too.
+
+JK: On the producer side, we’re working closely with J2WASM and Dart2Wasm. Kotlin also working on but have not heard recently. The ocaml team is also working on a compiler but I haven't heard from them in particular Targeting current version of binaryen. 
+
+JK: Re-using existing GC working well. Don’t have to work on GC at all. Turns out good performance requires wasm gc optimizations in engines and toolchains. on the engine side support feedback directed inlining. to be competitive with Java need similar tricks as JVM. kind of unfortunate, but advanced magic helps a lot. In browser, JS interop creates some challenges. How much do we want to allow at the boundary when wasm tables access from JS. Calling out from Wasm GC to JS for string operations, e.g., locale aware strings. Could bundle all into wasm but is not convenient as browser already have all the data. touches on stringref proposal. May still want to delegate to browser. 
+
+JK: Early performance data. Room for optimizations across the stack. My background is the web. Obvious competitor is JS. We have a fairly clear win for app startup, easier to have a fast baseline engine than Java. Wasm is approx 2x faster than JS. Wasm GC somnetimes lower, sometimes faster. JVM often ends being 2x faster, in some cases slower. Dart to native can be 12x faster than Dart2Wasm. (these 2x and 12x numbers aren’t comparable because 2x is sort of an average and 12x is a worst case) Module size compressed wasm 50%  bigger than JS equiv.In summary, do see some promise but we’re not done. Impact on specification is we do care about performance even on MVP. May want to make some changes even if not functionally required. It is worth keeping in mind that migrating large apps from Java can be a big investment. It must provide enough of an advantage to move. 
+
+RT: Can you clarify for these comparisons, you were saying about devirtualization? Is the wasm version the whole-program optimized, and the others are the standard JS/Java or are they all the same code?
+
+JK: So these are using the same original Java source and are then compiled with whatever the latest and greatest respective tool chain is, in particular for Wasm GC. That means, yes, binarian does whole program analysis and devitualization
+
+FM: When you said the migrating to Wasm is a big effort, you mean wasm versus JavaScript. If you have a compiler that generates JavaScript and… were the comparisons done from Wasm code to native Java code?
+
+JK: For a lot of applications you typically do have a bunch of specialization. So, we're working closely with the Google Sheets Calc engine and they have a bunch of special code that they wrote to, to get efficient JavaScript out of their Java, and they are now facing the challenge of writing the Wasm equivalent for all of that. So, I'm not sure how much time they've already spent on that, and how much more they're going to spend on it before they calling it done. But as an order of magnitude, its certainly engineering months, if not engineering years to just switch the compiler back end, so to speak. And that's aside from developing the compiler and tool train itself.
+
+CW: do you have thoughts regarding what you might want for post-MVP performance features?
+
+JK: maybe vtable support, a way of attaching methods to structs? Not sure what the details  would be but we'd want it to be generic. Don’t know yet how much it would help, so maybe it’s not the best thing but it is an idea we had.
+
+RH: with these numbers, is this just pure wasmGC MVP, or does it include e.g. the stringref proposal?
+
+JK: For now, without stringref, J2Wasm team has a patch, we haven’t tested performance, doesn’t change the performance all that much. The full story is a bit complicated, we’re cheating a little bit and I want to explain that. For this particular application it turned out that for this particular application, evaluating regular expressions is important.
+
+And the fastest way to do that is to use the blazing fast regex engines that browsers provide. And so, as a temporary solution, we gave them a non-standard fast conversion function from Wasm arrays  to JavaScript strings just so they could feed them into the regex engine. And that gave a big improvement for those scenarios that needed that and the stringref for proposal provides that. That might be a potential thing we can add to post-MVP - quick conversions between JS strings and ArrayBuffers and the other way around, so we can memcpy instead of having to pass individual elements across the boundary or something.. Stringref would be a standard way to do that too. By and large these numbers are without stringref.
+
+
+RH: Okay, my second question was, as another engine implementer, I'm curious how much feedback directed in lining helped out, just to kind of help. us plan, our long tail of whether this is something we'll want to investigate to
+
+JK: 10-20% performance, binaryen shipped their devirtualization which cannibalized some engine optimizations, you probably have to support it at some point of time
+
+RT: on function calls: ryan said they hadn’t implemented downcasting for functions, we talked about the performance impact of that. Are people using downcasting for functions?
+
+JK: I don’t think so
+
+TL: dart said they are planning to, but no one has yet
+
+JK: We have it implemented for the callref, had that from the get go, we have a patch that hasn’t landed for Call indirect, it seems to be doable, pay as you go
+
+AR: can you elaborate why you’d need to downcast with call_ref? It seems unrelated
+
+JK: Not sure off the top of my head
+
+RT: the cost is that… not a cost for V8 because it uses caller-side casting. But for engines using callee-side casting, its extra work for the infrastructure. If it's not being used it might be worth pulling out of MVP until it's clear that there’s a performance benefit. Not a blocker for phase 3 though.
+
+AR: Open issues with the proposal. With the MVP, there aren’t many left which is good. The first one is Subtyping for call_indirect. Call_indirect currently does a type check to make sure the thing you are calling has the correct type. Before subtyping this was done with a pointer check. With subtyping, you’d expect this to work for subtyping. It’s a bit more work to do, you can still do a comparison on the fast path, but you have to fall back. We think it might not be too costly to do that. There is concern about JIT code size, because if you have a slow path at every call_indirect, might make a difference. Consensus is people would like to have subtyping there, but we need to experiment here.
+
+RT: for this application of subtyping, what we did is when one class declares a signature and other redeclares a subtype and you want to use the same vtable slot. You want to make it so a funcref can handle multiple types, and you can list 2 types that you expect will work. So that solves the problem and you get a nice constant-time algorithm. So that's one reason to use callee-side casting.
+
+AR: It’s not entirely clear how you’d apply that here because this has to work with existing functions of call_indirect. You can’t presume a new language feature being there to solve this problem.
+
+RT: it’s pretty easy to add this with an instruction for funcrefs, we can discuss later
+
+BT: from my experience the callside checking of signatures is a lot, it might be worth trying to move to callee-side to reduce the code size overhead
+
+AR: Yeah, I think that that's a discussion we had some other point, I kind of fear that if you did that, you would have to do that in every function, right? Because you never know whether it's going to be used in that context. I think you only need to do it for functions that are called indirectly. But how do you know that beforehand at the definition side of the function?
+
+BT: i think you need only to do it for functions called indirectly.
+
+AR: how do you know that beforehand?
+
+RT: if there is a ref.func, that creates a func ref, that's where you set up the code. So, there's already some other systems or some stub code there for handling this. 
+
+AR: good point, you pre-declare when you use them first-class.
+
+BT: yes, that's the intention, so you do know
+
+AR: The next thing that came up is we introduced this new instruction array, array.new_elem allocates an array and takes the elements to initialize from some section. And you want this to be used in a global initializer like array.fixed, the problem we ran into is the very strict ordering section in wasm. There is a cyclic dependency, so right now we simply say we don’t solve it and you can’t use this constant expression right now. The cleanest solution would be to lose the very strict section handling, so we allow sections to be differently ordered. In general cases, you may want to split a section up to maintain legacy. We could also introduce a hack around dependency ordering of sections. The question is do we have to do this for the MVP.
+
+AR: Then there are aesthetics, the opcodes have grown organically, currently somewhat messy. 
+
+AR: We have started talking about the JS api. proposing a minimalist approach. when pass wasm gc object to JS it will appear opaque, no properties. Js prototype access will throw, to align with JS shared struct proposal
+
+AR: The main open question is there is this abstraction to and from wasm values, which describes what to do with the values at the language boundaries. What do we do when there are types that we don’t support? We could support all types or find some interesting place in-between?
+
+AR: That’s all that’s left for design. We still need to write the actual spec, there is an MVP doc that is concise. Main challenges are we need to carefully spell out the types. We need to extend the store model to include GC heap. We perhaps need to find a new owner for the JS APi spec.
+
+AR: Close to having two complete implementations.
+
+RH: On the open questions, I think there’s more discussion to be had about i31ref. I unfortunately wasn’t able to attend that meeting, but I think we should discuss that more.
+
+RT: you mentioned forward compat with the JS structs proposal. A key role of that is how to share objects across threads. I tried to investigate how to make that work and ran into 2 problem.s one is that a key idea of that proposal its prototype shape is fixed, so you don’t worry about another thread changing the shape. In this proposal its hard to see how to make it so you can fix the prototype. The other issue is that part of that proposal is upposed to eventually have typed arrays of some sturct, and again it’s important that all the values in the array have that expected shape or a sub shape. And it’s not clear how to give such arrays to wasm and have them preserve the invariants. And vice versa from wasm to JS. so we shold look into that for phase 4
+
+JK: so shared structs and wasm gc objects aren’t the same thing. Wasmgc wont support threading in the  MVP. when i talk about alignment, one way to summarize it is that we can maybe see a future when they could become more or less interchangeable and we don’t want to create any blockers that would prevent it. There will always be differences between wasm and JS obejcts but  it would be good t keep them as close as possible, it would be weird if there were 2 things that are close but not exactly the same.
+
+JK: JavaScript shared structs and Wasm GC objects are not the same thing. And no one says that they are. In particular, as you just pointed out, JavaScript abstracts are specifically meant for multithreading whereas Wasm GC MVP will not support threading. so, when I said that, we're trying to sort of align the proposals there, I guess one way to summarize it is we can kind of vaguely blurry, see a potential future, where maybe these things will become more or less interchangeable or at least, where JavaScript code that uses one or the other doesn't really care which of the two it is. And we don't want to create any blockers. That would prevent this future from happening. We can't be sure whether it will actually happen. And there may always be differences between WASM objects and JavaScript objects. But we figured it would be good to make them as similar to each other as possible. Firstly to have this potential future unification or at least even closer matching then they are for now. And secondly just because it would be weird to have two things in the JavaScript world that are almost the same, but have some some differences that would have been avoidable if they had, if the people designing them have talked to each other. And so, we are making sure that we do talk to each other as we design these things.
+
+SYG: Interjecting as I work on the shared structs on the JS side, on those 2 points Ross made, I don't think those are quite correct. I don’t know of any blockers that would make them fundamentally incompatible. As a general design knob it’s fine for structs to e.g. take on some different properties when converting on the boundary. But structs is also earlier stage then gc, so we can certainly tweak things.
+
+**Poll**: GC to phase 3
+|SF|F|N|A|SA|
+|--|-|-|-|--|
+|19|16|7|0|0|
+
+#### JS Promise Integration + phase 3 poll
+
+FM presenting [slides](https://docs.google.com/presentation/d/190wPxyzvQBKokPW9SyT-Jb2SUu-aUFrEraV3DKwRf4Q)
+ 
+FM: Javascript Promise Integration( JSPI). What is JSPI? Allow a wasm app to suspend itself when receiving a promise from an import and get woken up again when a promise is resolved. And to do so as efficiently as possible. It looks like a suspended application is kind of turned into a promise. We’re not changing the behavior and we’re not changing JS itself. We’re not permitting JS apps to be suspended in this way. We’re also not changing the wasm spec or any instruction of the wasm program. We’re changing the boundary edge between JS and wasm. The way it works is we take a wasm module and we put special wrappers on the imports and exports. Those wrappers talk to each other. When a wasm app calls a promise returning function, the wasm won’t see the promise, the promise instead used as a signal to suspend the wasm application, and a promise pops out on the other side. When the promise is resolved, typically when the IO is ready, then the callback for the promise is called. And that promise will wake up the wasm app and give the value the wasm app is expecting.
+
+FM: There is this notion of a suspender object that connects these two together. For ex, when you want to do this wrapping, you use part of the JS type API, so we have a dependency on the js-types proposal. We’ve extended the wasm.Function to include a parameter that gies guidance on how to handle the imported function. That means if there is a promise on the extension, then the function can cause suspension. You tunnel the suspender object between the import and export. And the argument on the suspender says which argument has this extra value. 
+
+FM: We’ve had a bunch of fairly minor tweaks based on review. The first is that we’ve been made aware that TAG (https://www.w3.org/2001/tag/) has a bunch of Guidelines around this proposal. They suggest that if you are going to return a promise, you should always return a Promise. Take a value on the import side, call Promise.resolve on that value and that will give you a Promise, even if a value wasn’t available? If it’s a Promise in a Promise, that bit of indirection is removed. Always consistent behavior.
+g 
+FM: On implementation, we have an experiment implementation in V8 and Chrome. So if you turn on the right flags, you can play with this. It’s experimental, meaning there are definite limitations. Available on Intel and ARM, on Linux, and macOS. If you are going to use it, use the dev build of Chrome because we’re updating implementation. So if you use the stable version of Chrome, yours will be out of date.
+
+FM: One of the limitations of the experimental phase is that when you create a suspend object, it’s allocated on the stack at a fixed size, probably the wrong size. So we wanted a stack management strategy that allow for stack growth.
+
+FM: When you have multiple stacks in your system, you have a choice over how you implement these stacks. We did look at a large fixed stack, but that runs out of VM quickly. We’re going for a more nuanced, less wasteful approach. 
+
+FM: Also working on a proper integration with V8 GC. We have an implementation but if you have a large number of suspends in your application, you’ll experience jank. Also trying to improve performance to fix an issue with accessing JS/Web APIs from the stack. So if you have a suspendable application and it calls JS, it’s not allowed to suspend. But if it calls a Web API, and then API is written in C, then we have a problem with that.
+
+FM: Also working on tooling, experimental extension to Binaryen and Emscripten that allows some use of this, but is not in the final state. In progress. We want a similar API to Asyncify.
+
+FM: Users. The biggest user is DART, they have an experimental implementation. Cleverly, they have implemented async functions & generators. Very much a polyfill for DART and hopefully not the final version. Very helpful for finding bugs in the system. Hopefully in this quarter we can start outreaching to people to see if they take a chance on trying out the API. We expect this to be fairly easy for the user to integrate.
+
+FM: The specification is more or less settled, but we don’t have a formal specification at the moment. We have a hard dependency on js-types, so later today we will be moving the JS types proposal forward. Mozilla is interested but doesn’t have time right now, expected in 2023. See opportunity for WasmTime.
+
+**Poll**: JSPI to phase 3
+
+|SF|F|N|A|SA|
+|--|-|-|-|--|
+|11|20|10|0|0|
+
+#### Threads update + phase 3 poll
+
+[slides](https://docs.google.com/presentation/d/1x-dFP4cbnH6IfTzOJxZRAM_ixAM1bhI5s1gfHHzAozM/edit?usp=sharing)
+
+CW: All of concurrency without a way to create threads. The basics is we’re introducing a shared attribute for memories that allows them to be shared across module instances in multiple threads. So on the web, if you try to postmessage shared, then it’s passed by reference.
+
+CW: Also introducing a suite of sequentially consistent atomic operations. We don’t allow instantiated state to be shared across threads, except for shared memories. Implies that source programs compiled to wasm+threads must do some coordination in JS to instantiate copies of code in each web worker. postMessage transfers shared memory reference to each worker, this is just what we’re doing in the MVP. 
+
+CW: The current situation with threads is that every web browser has shipped already. To get to phase 3, we have technical requirements, not implementation: test suite has to be updated to cover the features in its forked repo. In order to satisfy the phase 3 requirements: we updated the wast format to support multi-threaded tests. Introduced a threads block that says wasm modules and assertions should run in a web worker sub-thread. We have a proof of concept mapping to web workers implemented as an extension of JS test extraction in a branch of the spec repository. Implement support for all atomic operations in the reference interpreter. Writing a basic suite of concurrent tests to capture the basic behavior that we can guarantee will be common among all implementations. Our suite of tests is called the “periodic table” used in academia to capture the basic concurrent behavior this proposal is allowing or denying. These tests are not aiming to be production level, completely exhaustive of all that can be done in a concurrent environment. I'm very much focusing in this presentation on whether we're meeting the Phase Three requirements. I don't know if any implementations want to speak up about their first testing
+
+AC (chat): are you also doing fuzz testing? sometimes folks do fuzz on the side, which is a shame in a way as it isn't formalized like spectests are
+
+DeeptiG: We have code fuzzers in V8 which test atomic operations operations. We have the Binaryen fuzzer ported which has found some implementation issues in V8. We also have stress tests, which we aren’t very confident that it’s getting extra coverage, but we still run them.
+
+CW: Implementations that ship threads are doing their own tests. And it's already up in the air. Whether those satisfy the tests we requirements for Phase Three but just to be completely sure, we're doing it to spec tests instead. Example, message passing, one thread wants to communicate to another thread that work is done and they can go look at the result. One thread says where the workdata is to be read and a status saying whether the work is complete. The other thread reads the status message, and then reads the workdata in the location. The idea being that you can never read the status and then not be able to read the data, because of the use of atomics. 
+
+CW: Store buffering example, is it possible to see an out-of-order execution with respect to what is going on here. In sequential interleavings, it should never be possible to read 0 twic,e because by the time you are reading, you’ve already done the writing. For non-atomics, wasm has to allow this, but if you use atomic operations for your loads/stores then this is disallowed as you might want. We have a test for this.
+
+AC<in chat>: this is a web standard, hence the Web Workers bias, but is there any insight into non-web practice on this proposal?
+
+Dan Gohman: There is an effort called wasi-threads, which is currently in the prototype stage, but is making good progress.
+
+AC: I assume this is in wasmtime?
+
+AB: Yes, but it looks like there is another implementation in progress too (Wasmer)
+
+AB: Also, where are these spec tests?
+
+CW: Everything will be pulled together when everything is merged, but you should be able to find the “periodic table” of tests on a branch that ends with poc.
+
+SC: not just the web, but also node.js workers work the same way and also work.
+
+MD: this proposal doesn't have instructions for creating threads,why is it called that?
+
+CW: took over after the proposal was created, didn't seem worth it renaming
+
+TL: in the spec tests, you're not only testing that the atomic instructions, do the correct atomic things. You're also testing that the non-atomic instructions can do the “wrong” behavior?. 
+
+CW: Yes. So it's very hard to test for the absence of a behavior, right? Because you have to iterate a lot of times and check probabilistically. But yeah, the test does capture that the bad behavior is allowed for normal atomics, but disallowed for atomic. So there are two versions of the tests. The one where you run the non atomic version of the test then it checks what's allowed and quite a lot of things are relaxed because even the bad behaviors can happen. Then for the atomic version of the test, very few things are allowed
+
+DeeptiG: What engines do is roll some of these spec tests into their own kind of testing infrastructure. Do you expect that to be straightforward with the periodic table test?
+
+CW: The Shape of the test itself is very simple. I guess there would be a question as to whether engines would want to support the general, the generality of the threads construct. that we added. It is similar to how WebWorkers get created and PostMesssage, not sure if engine will want to do something that powerful for every test
+
+DeeptiG: we do some form of reduced workers on v8 API, may be possible for some variants of these tests
+
+AR: For these tests there, there are various different variations of these load instruments. Does it test all sorts of combinations?
+
+CW: Exactly does it doesn't test all of them yet, but I think that would be trivial to just copy and paste them and change.
+
+AR: can generate them? like SIMD?
+
+CW: interesting, can explore, probably not complicated. Main thing is to generate atomic and non atomic variant, the behavior is different, might not be automatic
+
+BT: Do they test that globals and tables are duplicated for threads, in the wast format? is that the intended semantics?
+
+CW: tests do not let you express that the same module is instantiated in 2 tests, it checks that bytes are there
+
+AR: doesn't allow you to share anything that is not sharable
+
+CW: if you try to pass something that is not a shared memory, it syntatically disallowed
+
+SN (chat): does WASI prototype build on concurrent memory spec, or thread creation primitives?
+
+CW: My understanding is that supporting the atomics themselves is trivial and the only question is how are these threads created? So these atomics were already supported and wasi_threads is adding capability to create the threads on top.
+
+DanG: (thumbs up)
+
+AR: Does the test suite include tests about tiering behavior?
+
+CW: no, tests do not attempt to catch engine optimization, only capturing basic semantic behavior. Each engine is the best to write those.
+
+BT: he meant tearing
+
+CW: That's an interesting question about mixed size. These tests are not focused on mixed size behavior. Of course here no tearing is allowed. If tearing were to happen, we would see non-allowed behavior. If tearing is allowed it would be harder to capture the fact that it’s allowed. 
+
+AR: It's also with mixed size. You can have tests where the base address is different. So we have a couple of those already for wait and notify but I think this fits in generating lots of different variants of the same basic shapes. And that's something I think that could be productively done automatically at least for non-atomic tests.
+
+CW: have couple of them for wait and notify, need to generate for different shapes and sizes, atomic tests have to be handwritten since behavior is very different
+
+RT: The performance issues for functions, a lot of the overheads are caused by the instance, object model. And from my understanding the sort of every webworker being, its own instance, is the primary thing that pins that instance object model. As you said, all these web browsers have shipped using it, is it just too late to try to address that problem?
+
+CW: So, with respect to the problem that each thread needs, its own instance. That's at the very least, is definitely just because we're an MVP and we have a grand plan to allow components of instances to be shared between different threads with respect to whether assembly. Having the instance model at all on the Indirections that come with that. I think that's not something that can be solved in the threads proposal, but maybe someone else has an opinion about that.
+
+DeeptiG: Not an opinion, but I think engines continue to make improvements on how expensive workers or instances are. So this seems to be more of an optimization concern versus a spec concern so that we can't probably do anything in the proposal
+CW: the issue of each thread needing its own instance is a spec concern in the sense that we’ll need to add shared attributes and such. We're just going to try and make sure what we have gets into the spec because everyone is shipping it and then do the improvements afterwards. That would be post-MVP. 
+
+AR: I guess it's also important to note that much of that is coming from the Web platform, right? As a constraint. So, That disallows very explicitly, just sharing our tourist stuff.
+
+AC (chat): one note that applies to nearly all spectests is also true here. I think each test could have an overview comment about what it is intending to prove. being an implementor, I'm often trying to unwind intent and in lieu of that mentally compiling the tests to guess.
+
+**Poll**: Threads to phase 3
+
+|SF|F|N|A|SA|
+|--|-|-|-|--|
+|26|13|3|0|0|
+
+CW: Next steps, pushing forward our procedure, hacking on the spec. So currently, we only support sequentially, consistent atomics in the spirit of a MVP. This is all you need to target webassembly, but it does mean that if you have a source program, using a weaker kind of atomic like relaxed atomics or at least acquire atomics. All of them essentially get upgraded to sequentially consistent atomics when you compile to webassembly.
+And this means that these accesses turn out to be more expensive than they necessarily need to be, or would be expected to be if you were compiling the same program to native. So, while x86, for example, this means that you might expect these atomic accesses to be compiled to bear move because X86 has a really strong memory model but because they're upgraded to SC, they get compiled to locked exchanges instead which is much more expensive. And on V7, it means every store gets an extra barrier. So, obviously, this isn't ideal and step one for more performance, might be to simply add release acquire atomics to webassembly. And this would unlock quite a lot of performance for x86. In terms of the compilation model, it would improve things for arm although not completely solve all of the problems in comparison to native compilation
+
+And it turns out the SC atomics are unnecessarily expensive. ARMv7 every store gets an extra barrier. Add release-acquire atomics to wasm would help with x86 instruction selection when the SC atomics are upgraded. JS proposals like GrowableSharedArrayBuffer will improve performance issues here.
+
+CW:  A different kind of strain of relaxatomic. Is to spread the shared attribute out from shared memories onto every other construct in the wasm language. So functions, globals GC structs when the GC proposal standardized, and this would allow them to be posted or shared by reference between threads as well. And this is quite an ambitious idea because as I kind of alluded to earlier, would require JS engines to go and think very hard about how they garbage collectors work. But there is a strong analogy to the technical work needed to support the JS shared structs proposal. So if we're getting signals from implementers that the JS, shared structs proposal is viable and they think they can implement it. That's a good sign that the shared attribute for webassembly is something that we can look towards as well.
+And once we have this, it becomes trivial to add a proper fork instruction to webassembly. So we can create threads natively rather than relying on the host. In particular, you could fork shared functions since we're already expecting multiple threads to enter them. And then fork and just continue executing from within that shared function, in a different thread. I don't know if any one has any questions about these kind of vague post MVP gestures.
+
+DG: we also at some point talked about a pause instruction, e .g. How to reason about performance hints 
+
+CW: In my mind it’s kind of analogous to branch hinting, so IMO we should have a uniform approach to that if we can. So maybe that’s an annotation on a branch or something like that.
+
+MD: So spin lock relaxation. The pause instruction is a native instruction. It's called pause on X86 and yield on arm that hints to the CPU core that it's in a spinlock where it's waiting for some set variable to change. And when multiple threads are on the same core like the CPU knows that. Until the next cycle of the system bus, the stride is going to just run wasting resources. So it can yield all resources to the other threads in the same core. Until the variable possibly changes on the next bus cycle. So it's an interface to hardware features when targeting native ISA
+
+CW: Would you agree that this is analogous to branch hinting?
+
+MD: diff with branch hinting is that this is a hint to compiler, this translates to actual native instruction, this is more like atomic instructions
+
+CW: Yeah, we'll take this offline. It's an interesting thought 
+
+AK: Curious if you personally have any plans to to work on any of this future work as champion of this proposal?
+
+CW :Oh absolutely. I mean, obviously the shared attributes, we had the paper back in 2019, describing how that would work at a formal level. We would want to see signals from implementers that they think this is feasible to implement as well before we started thinking about it, stuff like release acquire atomics, is reasonably simple to do. So I'd be very happy to write up what that would look like.
+
+RT: more forwarding a request from before, related to linear memory GC. for them to make their collector work multithreaded, they thought it would be very good to have a way to pause/suspend a remote thread in order to scan its roots
+
+CW:  have to think very hard about how to make that happen. So certainly one vision might be that, you know, using the GC types proposal with Shared attributes is the easy way to get at all of the complicated, concurrent garbage collection. That engines will need to implement to support that and then you don't need to worry about it in the wasm code, you're generating but I'm sympathetic to the fact that some people might want to compile their runtimes direct to webassembly, and I don't have a good answer for how they would do that in the concurrent setting yet and I'll have to think about it harder.
+
+PP: about pause, it's probably more similar to the instrumentation to the branch hints, it's also an instruction in hardware
+
+RH: So can you describe a little bit how the shared attribute would work with a model would everything in the module have to be marked shared? I'm specifically wondering about the case with a global could you have some globals that are shared some that are not and then does fork imply that they're like copies of the non-shared globals or…
+
+CW: Shared is effectively a barrier that prevents you from accessing non shared things from a shared context. Wrt globals and fork, maybe we need a third kind of attribute, for thread local. Implementing TLS in a nice way is kind of up in the air, you could fake it inefficiently without this. But not thought much about it yet.
+
+CW: There are two questions in there. I was going to answer the more interesting question first , so the way shared works of the high level is that it's effectively a barrier that stops you from referencing non-shared things when you're in a shared context and this is a way of keeping the garbage collection, kind of nicely segregated. So if I have a shared function, there are limits on what shared things I'm allowed to hold inside that function as references if I'm going to pass that function around as a closure later on things like that, with respect to how Globals would work in the presence of fork. That's a really interesting question, it may be that we need a third kind of attribute, that's thread, local or something like that. So that when you fork a function running in an instance, you get fresh copies of the globals for that. Particular threat. But, yeah, implementing thread, local storage. And a nice way for fork is up in the air, you can always fake it in an inefficient way even if you didn't have this new attribute, but yeah. To be thought about. 
+
+RH: Yeah. Okay. That makes sense.
+
+#### Relaxed SIMD + phase 4 poll(?)
+
+ZAN Presenting slides https://docs.google.com/presentation/d/1sqZy8B3D55r_J2_EDjy4m9u-fqbu55b2rM6eSftcKeM/edit?usp=sharing
+
+ZAN: Some instructions penalize particular architectures
+E.g. fused multiply add
+Not supported on all architectures
+2x speed up, but emulation v. expensive
+
+Goals: Fast, near native performance but identical not on all architectures
+
+19 new instructions, cf >200 instructions in regular SIMD
+Not generated by default in toolchains, requires opt-in
+
+Existing non-determinism wrt NaNs
+Relaxed means set of allowed results for relaxed instructions (as opposed to a single allowed result)
+Fixed for a particular instance
+
+Phase 4 requirements: V8 & Spidermonkey; Emscripten/LLVM/Binaryen
+Formalsm & reference interpreter 
+
+DanG: On the slide about the builtin names, a few “fma” instructions don’t have “relaxed” in them, is that intentional?
+
+MD: This is an artifact of prototyping, final names should have “relaxed” included. This names are internal names in the prototype. The final names would have a proper interface. They would have user readable names due to the nature of the V preprocessor. These names are effectively public interfaces. 
+
+TL: I’ll make sure this is updated in LLVM
+
+BT: Live migration ‘becoming a thing’ on the web, when is the semantics fixed?
+
+ZAN: I think these systems that migrate code, they will have to know the characteristics of the platform that is running it and ensure that migrating will not cause any differences.
+
+BT: Is there always a backup like, For each of the relaxed ones so they could do the conservative thing. That's not faster. 
+
+Room: <Yeah.>
+
+ZN: So this instructions that are highlighted have non-relaxed versions. and for the rest, it's case by case. Names are not updated here, relaxed fma is really relaxed mul+add. The dot products don't have a similar instruction in the SIMD proposal. Marat said something. 
+MD: Yeah, so the instructions highlighted directly map to Wasm SIMD instructions with potentially worse performance, but with deterministic behavior, and for the rest of the instructions, we provide reference implementation on top of Wasm SIMD  instructions.
+
+AR: Somewhat concerned. Consciously introducing implementation defined behavior. What does this actually buy us in terms of numbers? 
+
+AR: As you might be aware, I'm somewhat concerned about this proposal, right? Because, yeah, it has a much wider impact on webassembly as a whole and, and its ecosystem because for the first time, we are consciously introducing implementation dependent behavior, which kind of, breaks one of the value propositions we had for WebAssembly. So first of all I'm wondering and this is all motivated by performance of course, but I haven't seen any performance numbers in your presentation. So what does it actually buy us in terms of numbers? And I would be curious to hear that. And then I have a couple of follow-up questions.
+
+DG: On the instruction issues themselves there are detailed performance numbers.
+
+ZAN: [showing a slide with performance improvements for qfma, a predecessor to relaxed_fma] So I had a slide that  I believe this is from earlier, prototype them around it on qfma which is the relaxed mul add instruction and more specific to the different processes. So we prototyped several optimizations. This one is using what is now called. Relax multiply add, another prototype we did is using relaxed q15 format multiplication. It's a special multiplication instructions that are accelerates and conversion between different quantized data types by about 50%
+
+AR: So is this application benchmark or like since that benchmarks are end to end?
+
+MD: Benchmarks on network inference across different popular models. And several benchmarks across several hardware models show improvements
+
+AR: okay yeah this looks like good numbers. Thank you for that. That was very helpful. so, the next question would be how do we limit the damage? Want to do this so that there is a defined way how to know what the semantics of webassembly is, if you need determinism, which we currently don't have
+
+CW: I think profiles are probably a good idea for the spec, but there are other things we’d want in profiles, e.g. GC types. I don’t think we’d want to hold those back.
+
+AR: I would
+
+CW: I think the onus would be on profiles to be completed before this becomes a problem. I don't think we'd want to actively block a proposal on waiting for profiles to be finished.
+
+AR:. Yeah, I personally, I disagree with that, but because we're creating this situation where we have a standard that some people just can't use, right? and, Which to some degrees is already the case with SIMD. But at least for SIMD, there's a clear way how you kind of work around that by normalizing Nans. I, so, that would be, let me say that would be the absolute bare minimum. I think what this proposal would have to do is to define a canonical deterministic behavior for all these instructions. So that at least there is a clear Implementation with a path forward for systems that can't afford non-determinism.
+
+MD: We have reference implementations. Already possible to detect architecture using NaN behavior. 
+
+AR: Two separate things: 1) whether you can use this for fingerprinting or 2) which semantics would I pick if I want deterministic semantics (which it sounds like you have).
+
+MD: yes, there is a reference semantics for deterministic systems.
+
+BT: It does seem like this is a kind of a cross-cutting concern to the spec like we are. fundamentally changing our stance on determinism for this one specific case. So I think it takes a little bit more. I mean, you guys have done great work, it is a high bar, and we have to think about a change in how we specify things.
+
+RH: AR, you mention this is adding implementation-defined behavior. Can you say what’s at risk here, what are the negative effects?
+
+AR: I was hoping this is self-explanatory. Wasm is a portable code format. Determinism is part of making code portable. Implementation-dependent behavior is on its own plainly bad, it’s perhaps a necessary evil in some cases. Determinism is one of the things that people like about Wasm.
+
+AR: Need a future oriented stance: what forms of non-determinism we will accept in the future.
+
+RH: is the desire to have this consistent behavior: is this only for relaxed madd, does this affect the other instructions as well?
+
+DG: What do you mean by affecting other instructions
+
+RH: We can ‘get away’ with non-determinism with NaN but this is not true for other instructions such as fused madd. I.e., a bigger impact. Have we considered an alternate formulation that allows feature detection, and then only using the instruction when it’s available and will be consistent.
+
+MD: all instructions have the property that they give the same outputs for the same inputs when the inputs are in-bounds. If you don’t care about out-of-bounds results then you can use these instructions without worrying about the non-determinism. 
+
+DG: We need to be more concrete: what is the exact concern? How we decide to spec what we introduce. Not catastrophically bad. 
+
+AR: depends on where you’re coming from, but yes. In terms of spec, we are complicating the spec in a way that is not localized to these operations. (there is a way to do that but we aren't). But more broadly , what does it do to the language in general. On way to explain the difference with nans. Before we had non determinism because we couldn’t do any better, a necessary evil. But now we are intentionally providing a feature that people are supposed to use in an implementation dependent manner. We are blessing that and that's very different. 
+
+MD: the main goal is not to unlock implementation specific behavior, it’s to unlock the case where things are used in range and no implementation specific behavior needs to be involved
+
+RT: My impression is that for many programs they use these instructions within range which has an agreed and single result for operations.
+
+CW: I don’t think that correct
+
+DG: [off mic] MD has a better answer here
+
+RT: the alternative seems to be that the program specifies 2 different ways of doing the same thing, and test which version you have implemented.
+
+TL: The feature-detection proposal is no longer active, and was never intended for platform detection, but for Wasm feature detection (whether a feature is there).
+
+MD: The goal is not to promote different implementations.
+
+BT: we’ve talked about various options, one to spec the union, the deterministic variant, and then additional way to test which one is fast, and you can detect. It’s deterministic but if you pick the wrong one it’s very slow.
+
+MD: In many cases, that complicates development and makes it hard to get optimal performance everywhere. E.g. relaxed_min and relaxed_max: the trouble is that there’s one instruction that’s fast on x86 and one that’s fast on ARM. you can detect which one youre on, and dispatch the fast one.
+
+BT: You can do this using a branch.
+
+MD: The goal of this is to avoid those branches.
+
+JM: to AR’s point: a lot of work has been done to pick the instructions well and make reasonable compromises, but the idea of implementation defined behavior is bad, isn’t just theory, this tangibly introduces a case where if im an app developer and i can’t afford 2 different CPUs, there's no way to test my application in the presence of both semantics. Now I need to have both pieces of hardware or use a slow emulator. So it’s not just theoretical, there is a practical element. But at the same time nobody really wants to have their lap burn because it’s nice that wasm is completely deterministic.
+
+KW: Requirement to always return the same value is part of the spec prose, not in the test suite. It is also difficult to test that well. But it would be really good if the spec tests required that too
+
+CW: AR: how happy would you be if we had relaxed simd, and then standardized profile, and then having relaxed simd be only the “everything” profile once profiles are standardized. How bad would that be.
+
+AR: I think it would be way way better if we had profiles first.
+
+SN (on chat): is relaxed simd guaranteed to produce the same values in all cases IFF the wasm program is run on the same machine?
+
+ZAN (on chat): given the same inputs, yes, on the same runtime env, e.g. if you run on an engine but disable FMA via flags, then that's a different runtime env
+
+DG: a followup question: given that this is dependent on how we spec this: there are 2 concerns, the impl-defiend behavior, and also profiles and how we spec. Are those orthogonal?
+What if we ship this and then wait to merge them into the spec until we have profiles? 
+
+AR: Sounds reasonable to me. We’re already in a somewhat weird state with plain SIMD where we have a feature in the spec that’s not going to be implemented everywhere.
+
+DG: Wanted to address implementation-defined behavior. Something ZAN may get to later is, which applications are expected to make use of this proposal? They’re niche applications, which opt in to using the new instructions directly (not via, e.g., the LLVM auto-vectorizer). That doesn’t address the overall concern, but I wanted to say that in practice the non-determinism is limited to the niche uses of the instructions.
+
+NAS: as an application developer when we write desktop and mobile apps we tune to hardware very extensively. I like that this is opt in and not on by default, but if you know how to use it safely then I don’t see what the major concern is
+
+AR: This concept of restricting the toolchain is a fallacy. With complex toolchains and applications it can be very hard to contain the impact. It also risks fracturing the eco-system. In a deterministic profile, you could forbid these entirely or pick a deterministic semantics. The latter would sort of defeat the point of performance, but at least you wound’t fall over if you got something unexpected.
+
+RH: On the slides, you use the term “host”; what does that mean precisely? We have different tiers, we have different processes. It’s possible that a program is snapshotted by wizer and restarted again in a different environment.
+
+ZAN: Don’t know how to define host now, but ..
+
+BT: Going back to JM’s concern about testing, what if we get years down the line and find that some program is dependent on x86 behavior.
+
+CF: Ryan bright up wizer, a snapshot restore tool. I have that concern too. Maybe we should spec it where any of the behaviors is allowed anytime we hit the instruction to avoid the problem where you accidentally depend on a particular version
+
+MD: Two issues: first all relaxed multiply add go to one of two algorithms… It also exposes more entropy to enable fingerprinting.
+
+CF: is there a proposed way to implement this on a platform that does this kind of migration or snapshotting?
+
+MD: A platform that does dynamic migration should either use the deterministic lowering on top of Wasm SIMD, or if you have knowledge about the hardware shared across migrations, you could enable lowering for specific instructions that would remain consistent.
+
+AC: One thing I've noticed is that there's a lot of discussion about the topside of the use cases, the app’s ability to leverage things. Wanted to step back and say that 1.0 was touted as a fairly simple virtual machine. The 2.0 draft is quite a bit more complex than it used to be, and runtimes now have all-you-can-eat work. There’s a lot of dropoff for implementations. If we don’t have a budget of how many features we think are reasonable, it can sprawl out of control where only very large implementations with lots of resources can participate.
+
+DG: Responding to that, we do expect new features to come along. Yes, there is drop off, but we come to this forum to discuss with other implementers.
+
+DS: We could improve that through improving support for feature-detection and profiles. Even just on the web it’s work for developers to handle the differences between implementations.
+
+AC: The growth of the spec is already causing problems. Wasm 2.0 is already too difficult to implement.
+
+DG: I understand that concern but I want to separate that from this particular proposal. Would be pertinent for the roadmap discussion tomorrow. Will add an extra 30min tomorrow to discuss this proposal tomorrow, since I don’t think we’re ready for a poll today.
+
+PP: to Chris’s point, there is a suggestion that we can rewrite the spec in a way that every instruction just deterministically produces particular values. We might need specific deterministic versions of e.g. fma. Would that make it better?
+
+Chris Woods: Regarding the versioning problem: as a potentially wasm user, one of the thing we (seimens) love about it is the platform independence, and we support tools for many years, and insulating from old hardware is really great. We realize you have to take advantage of the hardware thats there and you have to compromise. When you use intrinsic youre really targeting a particular piece of hardware. But i’d love to see a more generic approach to how you support things over multi-decades, what features are used and required, deprecated etc. that would really help for that kind of scope that spans so many different device classes.
+
+AZ: I think tools like wizer and wasm-opt would not be allowed to precompute these new instructions because they might not match the host. We’d need a way to explicitly mark which version, but that wouldn't be great. But I think it’s not a problem, and the tools just shouldn’t optimize or precompute them.
+
+AK: People are excited about wasm because of the platform independence. But other people are also excited by access to the underlying hardware (cf other platforms). Determinism is not the only motivation.
+
+DanG: this problem will hopefully reduce over time as more hardware eventually supports more operations, hopefully they can converge.
+
+MD: While it’s true there are no ARM64 processors which don’t support FMA, there are laptops you can buy today that have Intel CPUs which don’t support FMA. This problem isn’t going away anytime soon.
+
+DanG: I’d like Wasm to last for 100 years.
+
+BT: The performance argument is super attractive. Should not leave this on the table unnecessarily. The solution is to allow the programmer to specify desired behavior.
+
+#### Component Model progress update
+
+LW presenting [slides](https://docs.google.com/presentation/d/16yWWzlmG76l5Ve9jxkjxCx2mYHhFLRjsy0CyzPu57Fw)
+
+LW: No polls here
+
+LW: Overview: summary of Component model, no sexps.
+
+CW: When you say you expect resources to be non-copyable, are they also immutable?
+
+LW: That gets into lifetimes, when a resource gets destroyed, etc. But they can be mutable. Don’t enforce immutability as part of this system.
+
+CW: But the point is that the shape stays the same?
+
+LW: Yes
+
+LW continues presenting at low-level concurrency slide
+
+CW: Are you expecting lifetimes to show up in the interface?
+
+LW: Lifetimes is a whole discussion topic, which we can’t go into right now. Actively working on this right now. Lifetimes are essential!
+
+LW continues presenting
+
+TL: Is this fusion the old Interface Types fusion?
+
+LW: Yes, but we’re only fusing canonical adapters. Don’t have the fully-general adapter language currently.
+
+TL: Would love to hear more about these languages that are supported
+
+LW: Not all at the same state of completion (only learned of some on Monday!)
+
+CW: Trying to get my head around lifetimes. When the canonical ABI was sketched, the questions of ownership was handled by copying. How is the lifetime going to be enforced?
+
+LW: This is core of the hard problem to solve. Starting with what you see in the Wit, if you see `blob`, it means transferring ownership. In the component model, there’s a table holding a reference to the blob; when the code is lowered to core wasm, the handle is an index into the table. When the blob is passed between modules, the blob is moved from one component’s table to the other.
+
+CW: Are handles tied to linear memory?
+
+LW: When you get a handle, it’s just an index.
+
+CW: So you need to call some function to actually interact with the resource?
+
+LW: Yes. We’re finding the need to express borrowing to avoid transferring ownership just to pass it back.
+
+BT: Exporting/Importing memory. If you want finer control, can you control this?
+
+LW: Components have a whole bunch of things inside them; they can have multiple memories. And then adapters can say which memory to read from, or write to.
+
+BT: Bidirectional interfaces? 
+
+LW: Imports say what you can call, exports say how you can be called..
+
+ChrisW: Jumping forward to the developer experience. Component model exists, and I’m writing some component. If I just want to run a single component, what does my runtime need to implement? Do I need to implement the whole wasi interface? Would like to run on constrained devices, and Wasmtime seems pretty big.
+
+LW: If all you’re doing is running a single component there shouldn’t be any overhead. Recommend measuring before you throw the component model out, the design is meant to support high availability, low-latency applications.
+
+PP: You compile a Posix app using llvm, C does not have a yield operator. How does a C app access async interfaces.
+
+LW: In C bindings, you’d generate a bunch of headers with `__` attributes.
+
+PP: You would have normal posix-like functions, you would have a shim that maps them  to component interfaces.
+
+LW: There’s also wasi-libc, which sits on top of the generated bindings, so some programs will keep working without any modifications.
+
+BT: Another big part of POSIX is signals, what’s the plan there?
+
+LW: Core wasm would need to give us signals first!
+
+BT: Thinking of two different sorts of signals, some dealing with errors and some dealing with cross-process communication. Is there some way for dealing with the latter?
+
+LW: We’re not going to put signals in Wit, but what we might do is look at what code that uses signals to see what the right way of supporting those patterns in Wit.
+
+DanG: May be able to create a signal-like shim on top of async/wait 
+
+LW continues presenting
+
+LW: Asks for core Wasm (slide): Implement multi-memory, Implement ES import-reflection, Data segment import/export.
+
+SC: You had a component wasm file. Do you expect a new kind of file?
+
+LW: This can be a layered spec, where the component model spec is layered on top of core webassembly. We’re thinking of reusing the same byte that marks wasm binaries and using 0 for core wasm and 1 for component. And then engines could treat those appropriately.
+
+BD: Do you expect this to be implemented in browsers?
+
+LW: No current expectations that browsers would implement, polyfills to start. Analogous to how ES modules rolled out.
+
+AR: On the topic of multi-memory. Who has implemented it? Any browser implementations?
+
+RH: it’s just work, it’s just been low priority. We’ll try to get to it, but no promises.
+
+TL: we have started using it in tools. we also have a polyfill of it, since engines haven’t implemented it. if people would implement it that’d be great.
+
+CW: How will borrowing work?
+
+LW: There’s no quick sketch, let’s talk offline.
+
+CW: It’s ok in my mind for the CG to curate specifications that are outside the W3C’s mission. In the very long term, you’re hoping for browsers to implement this. So the idea is that the component model spec eventually becomes published by the WG? Is it weird for the W3C to own this spec even if it’s not implemented in browsers?
+
+LW: I’m in favor of thinking of the web more broadly than “what’s implemented in browsers''. We might get a second implementation of component model beyond Wasmtime [even if not in a browser]
+
+BT: What is the story for WasmGC wrt resource ownership?
+
+LW: GC components can use GC types internally. What we want to avoid is cross-component GC. We have an acyclic ownership model, want to avoid leakiness if a GC component is linked to a linear memory module.
+
+AR: Using integers for handles seems old fashioned when you have references
+
+LW: How exactly to incorporate references into the component model is not clear. For now using indices into a table is working, as the table is owned by the component model.
+
+PP: Would be good to know for sure whether handles are integers or reference types.
+
+LW: What’s more important than integer/reference is how ownership works. Need to avoid cycles/cross-module GC.
+
+PP: That would mean you couldn’t use GC objects as resources.
+
+LW: You’d create a resource that encapsulates the GC object and hand that out.
+
+PP: A call in webassembly gets maps to a component call. How does that work?
+
+LW: You would write C code, and you’d use wit-bindgen to generate these bindings, and then you’d call those from the C code.
+
+PP: Take something simple, like printf. Does that need to be implemented as a Wit thing?
+
+LW: When you do a posix syscall, that is when you will cross the component boundary.
+
+AR: Following up on integers as handles, aren’t they forgeable, confuseable?
+
+LW: It’s like the kernel, each component has a private table. If you want to revoke access to a thing, you just remove it from the table.
+
+AR: You can’t verify when someone passes something on to someone else.
+
+LW: You have to enforce everything dynamically.
+
+AC (from chat): why is wit-bindgen in bytecodealliance but component-model in WebAssembly org. it seems a fundamental tool..
+
+LW: One’s a standard and one’s an implementation of a standard
+
+AC: Don’t fully understand that answer, since e.g. wasi-libc is in the WebAssembly org. I’ve seen some pingponging.
+
+DanG: This has been evolving, still trying to figure out where everything should live.
+
+#### Staged compilation and module linking
+
+AR presenting [slides](main/2022/presentations/2022-10-26-rossberg-staging.pdf)
+
+AZ: Isn’t module linking capable of doing the same thing as the JS API? What would be the benefit of using this?
+
+AR: That you don’t need JS. It makes the language for connecting modules part of the language itself. Which leads to every environment needing to express this in some way.
+
+BT: The intention would be that inner modules close over outer modules?
+
+AR: You can encapsulate some of your logic inside the module, that makes the logic more coherent., and you don’t have to rely on JS to do the right thing
+
+CW: How is module linking going to help us get at those things that compile-time imports would do?
+
+AR: Explained on this slide (“Staging via Module Linking”)
+
+AR continues presenting slides
+
+DanG: Can the inner module of imports of the outside?
+
+AR: In this example you have import io, and you have preimports before, if you put it in the right stage, so it does what you want it to do
+
+SN (on chat): Doesn't this design break the ahead of time compilation scenario?
+
+AR: Yes, we’d have to discuss that. This whole thing depends on whether it makes sense not to compile the inner module with the outer module. Depending on how you define it, “ahead of time” compilation does work, just doesn’t compile in the inner module AOT by definition.
+
+CW: Ahead-of-time compilation seems like it doesn’t have the problem that this is trying to solve, since you already know all the things you’re going to link together.
+
+BT: This is basically currying?
+
+AR: Yes, The outer module might have some exports as well, there’s no restrictions to what the outer module can define
+
+JM: For the ahead-of-time case, you already have this information. JITs would already have this information, since when they tier up `Main` they’d already have this information. What would this buy over what we have today?
+
+AR: <Explaining on the slide>, if you have a multi tier thing..
+
+JM: The only case where I see this being useful is something like the SIMD case.
+
+AR: It depends on how you define AOT exactly, I would define it as no tiering, you don’t want to dynamically recompile it like JS engines do, but nobody else does
+
+CW: This is something V8 does now, to inline when tiering, JK mentioned it in the GC presentation earlier?
+
+TL: My understanding is that this is something we might do in future, not what were doing today.
+
+RT: JK’s thing was dynamically inlining Funcrefs
+
+FM: Even if we thing compilation happens before instantiation, there’s nothing stopping engines from doing them at the same time, you could inline while compiling
+
+AR: The intention of the two-phase API is that it assumes that’s not what the engine is doing. For example when you postMessage a Module to multiple workers, you expect that there won’t be recompilation. You could also make it an explicit choice about how staging works.
+
+BT: The currying analogy, it’s intuitive that when <imports.. exports> what happens when you have a nested export? 
+
+AR: It’s completely regular as compared to import/export semantics, no magic involved
+
+RH: Trying to understand how much is the module linking syntax, and how much could be expressed in the current JS API. Could this be done with WebAssembly.compile taking in a module and a set of imports?
+
+AR: That’s how I started, assumption was there were pre-imports, these would become imports on the module constructor, but it doesn’t scale well, we don’t have to do that if we have nested module definitions, then we can do something more general
+
+RH: So couldn’t you take a module that’s already compiled and instantiated and partially apply those?
+
+AR: Because, you need to make restrictions, you can’t arbitrarily apply imports, becomes more important when you have type imports, certain imports may depend on typed imports, they might rely on the types being supplied
+
+RH: So during the compile step you have to provide the right set of imports?
+
+AR: the other part of the problem, if you do that transitively, it gets more complicated when you want to supply something as a pre-import and that’s an export of something else.. When you do staging right, all the things you have to have at one stage needs to be available
+
+SC: This might facilitate us actually using the start section to run C++ initialization code, since we could put those things in the pre-import section.
+
+AK: Regarding “reviving”, I didn’t realize the module linking proposal was dead. What happened to it? Did it get subsumed by the component model?
+
+LW: Component model says “assume core Wasm has module linking” but there hadn’t been any motivation for module linking besides that. This use-case might be enough motivation.
+
+SC: Does this mean we have first class modules and instances? 
+
+AR: Still second class, explain with slide “ Module linking syntax recap”
+
+<More discussion about syntax>
+
+RT: For importing types, not heap types but value types (useful for generics). With the model you’re proposing, you wouldn’t be able to import a value type and use it. Because when does it get compiled? It’s really a pre-import.
+
+AR: The way you could make that work is that the value type would have to be imported by the outer module, and then used in the inner module. A value type import would have to be syntactically marked separately, and you’d have to think about what the semantics are. And it’d need to be restricted in a certain way.
+
+LW: There are use-cases for nested modules that don’t want staged compilation, and ones that do. I’d want it to be an explicit tag.
+
+### Day 2 Discussions (Thursday)
+
+#### Extended Constant Expressions + poll for Phase 4
+
+SC presenting [slides](https://docs.google.com/presentation/d/1UuXMSuugbdtkQxt_qb5qOYOnTF5rrZk7n435uRsBg_w/edit#slide=id.g11a165de668_0_1)
+
+chat question: how about binaryen?
+
+SC: emscripten toolchain implies llvm/binaryen
+
+DanG: is that the same name as the instruction? i32.wrap_i64
+
+SC: maybe there's a different name
+
+SC: proposing we move that into memory64 proposal
+
+AC: not necessarily because of memory access, also extend i32u, also handy when doing things like shift
+
+SC: could delay another month and add wrap and shift
+
+AC: notice people packing 2 i32s into an i64, then use shift and wrap to initialize
+
+JM: not harder to do whole set of things you expect people to use
+
+SC: for me being toolchain maintainer, this set is exactly what i needed
+
+JM: any reason why this fixed set rather than the entire set?
+
+SC: could add things like blocks, but want it to be simple, didn't want to worry about traps and side effects
+
+AlexC: from engine impl perspective, any feedback about recursive, there could be infinite chained adds and muls, any issues with this?
+
+SC: engines taken different approaches, not sure if there are issues with that, can't loop, so can't go forever
+
+CW: on web we have fixed number of locals in implementation limits, do we similarly want a fixed number?
+
+SBC: do we limit the number of instructions? similar to it
+
+RH: we have limit of number of instructions, but we don't know length beforehand for constant exp
+
+SC: we can't jump over them, can't parse container format without doing instruction decoding
+
+RH: impl in SM is have a mini interp doing a validation pass when decoding. We have to do more verification, make sure we do all instruction exactly, not difficult and can simplify, but that's one reason why it is compelling to start small
+
+SC: in wabt, i use full VM, validator takes care of limiting instructions
+
+FM: AR has proposal for module linking, it suggests they want more powerful way of initializing globals
+
+SC: we have instructions available in this location, we can have the outer module that does instantiate
+
+BT: can't run code, no arith in module linking, just instantiate globals
+
+SC: outer module just runs its start function before inner?
+
+BT: unclear
+
+RH: make sense to extend constant expr, GC proposal extends this more, other proposal to add in arbitrary expression trees can make sense, 
+
+SC: if we get this, then memory64 will add some, GC add some, another proposal can add more
+
+CW: agree, start with what we have, ship extensions in other proposals. do we have limit on size of value stack, that's the limit if we use a small interp
+
+BT: implicitly yes, functions are limited in size
+
+CW: we might want some explicit limit on size of value stack - imagine many consts, then add at the end
+
+SC: another implementation limit, spec has those already right?
+
+TL: in the context of GC, for array.new_fixed, put consts on stack, limit on V8 is 1000, but people wanted bigger arrays, then JK made it 2000. It's high.
+
+CW: having that limit is good, browsers should align
+
+BT: we discussed adding new kind of instruction, size of initializer, either we have something grandfathered in that is legal, or declare the size using that illegal function
+
+SC: great to be able to skip over, i've written parsers for binary format, it’s best not have to write instruction decoder when skipping over data
+
+DS: given that the binary format for initializers today is just one instruction, just adding more instructions doesn't make it worse.
+
+SC: might make sense if we do a big addition of more instructions
+
+SC: closed out the issue on size that we can add later
+
+LW: const expr ...
+
+SC: previously it was just a single instruction
+
+LW: if we pick a cutoff point where we enable expression tree, this might be the point in time if we want an instruction limit, some binary hack could do that now
+
+RH: agree with LW, if this is what we want, this is the point that make sense, if we add expression trees, code has to support that in the future
+
+SC: ok, we will delay the poll, then add a new header instruction
+
+BT: global flags have a bit we could set in the flags 
+
+RT: we could also make functions have a special expression as their body
+
+CW: where are the places where this is used?
+
+SC: data segments, and globals
+
+CW: we have to make sure all those places have a bit free; just in globals isn’t enough
+
+#### Type Reflection for WebAssembly JavaScript API + Phase 3 poll (tentative)
+
+IR presenting slides <TODO IR to add link to slides>
+
+IR: one motivation is for mocking imports, another is to use Wasm functions as a subtype of JS functions; allows setting JS functions in Wasm tables. Implemented in browsers, missing spec text.
+
+RH: I don't know the full history of this, curious about adding type methods to globals and functions and tables. While I understand the use case of being able to mock, are there tools that will do this, or is it just something that can be useful?
+
+IR: right now it is a nice to have
+
+RH: WebAssembly.Function interface will be used by tools, that seems useful. Interference with GC proposal or function reference makes me wonder if we don't have specific user of those, make sense to focus more on WebAssembly.Function
+
+IR: another talk about how to extend JSAPI, no good story on how to align all these proposals. Possible to only bring it for WebAssembly.Function. Beside these type methods for global and tables, we bring all machinery to JS. No good justification to keep it right now, but seems right to have.
+
+AR: as the originator of the proposal, I should be able to answer that... but I cannot. Back then, there were requests for this ability. The WebAssembly.Function thing was an afterthought. People wanted to reflect on these, I cannot remember now what the use cases were.
+
+IR: one of the proposals that grows organically, people need parts of it
+
+SC: Emscripten has a use case for dynamic linking, so you can generate a stub function accurately, you need to know the signature ahead of time from the JS loading code
+
+AR: any use case where you want to do some generic processing of modules, linking or something, would want that. Reflection is always a questionable feature. Don't think there is that much issue extending with new functionality, just work that has to be done.
+
+SC: What we do to work around this, is that all our JS functions we need a type annotation so that we can create a Wasm function with the right signature, so the reflection would make it better
+
+RH: if this was shipped in browsers, Emscripten will use this?
+
+SC: We definitely would, we construct webassembly function with bytes right now. With types there would also be a burden we’re able to remove for our users 
+
+RH: sounds good to me, alleviates my concern
+
+**Poll**: JS Type reflection for phase 3?
+
+|SF|F|N|A|SA|
+|--|-|-|-|--|
+|11|14|5|0|0|
+
+#### Fiber switching
+
+FM Presenting [slides](https://docs.google.com/presentation/d/1qe8xIoZkKZY2ID-tU5ClO_8bD7sViOk9VuGm732qlx8)
+
+AC(in chat): related to why GC is no go (Go supports interior pointers which the proposal doesn't allow) https://github.com/tinygo-org/tinygo/pull/3162#issuecomment-1263496284
+
+AR: I agree with most of what you said here, confused about one point, provide mechanisms not policies, then you talked about capabilities, seems like the opposite
+
+FM: yeah, I forgot: language providers want mechanisms, not policies–definitely. But they are not the only stakeholders; engine owners are also. Engines need/want to define policies and capabilities would be how they do that.
+
+AR: what is your definition of policy and how do you separate it from mechanism?
+
+FM: Formally…a policy is a constraint on the behavior and state of a system.
+
+CW: what do you see in the context of what we are discussing, as the policy?
+
+FM: Capabilities are a policy the engine owner wants to enforce.
+
+CW: w.r.t. multiple programs interacting?
+
+FM: Engines are interested in protecting themselves–e.g., through capabilities
+
+RT: one example is if there are different domains of trust, component A wants to call component B, but doesn't trust B, can A make sure B can't use stack switching to bypass A's control?
+
+TL: w.r.t. capabilities, it came up in LW's presentation, capabilities are important to the system, in core Wasm, they are i32. When I hear capability, capability for what? huge design space there. We originally thought that ref types are the capability model, but in the component model,they are i32. Haven't been successful to bake capability into core Wasm. Design of capability model is design of policy, for core Wasm we want mechanisms. If capabilities are important, would like to hear more specifics about capabilities for what?
+
+FM: So, let’s take a function call: in the middle, we want the “capability” to return to the caller; inherent in the design of the machine. The i32 question is a trivial one–what really are the identified capabilities and design constraints? We want to be minimal.
+
+BT: I see these tasks that you can send events to, tasks can change state, next time it doesn't accept the same events it did before. Dynamic typing is almost inevitable, you need a more complicated system, a state machine.
+
+FM: So, yes, you probably don’t need it for the machine.
+
+CW: we are looking for some synthesis between the proposals here, is there a reason policy/mechanism came up in your presentation? Is this something that’s different between the proposals?
+
+FM: Yes, search is the difference between the proposals
+
+CW: both proposal can have some barriers to prevent that
+
+FM: Search is the more fundamental thing.
+
+ArjunG:: critical features that were mentioned, green threads, generators, async functions, we should also think about functions that compose these features, async generator that is also switched around in green threads, don’t know if Rust or Python supports this, let's future proof the proposal so we can support this. Kotlin, Rust, etc., they are typically statically typed, also think about more niche untyped languages, where you don't have that static information. That might affect what you can or cannot do with capabilities. Prolog is quite niche, textbook implementation relies on multi-shot.
+
+FM: The reason Prolog can’t use Wasm GC is because the Prolog GC has two GCs: one forward, one backward and the second requires historical integrity (will take offline)
+
+RT: maybe don't need to go into GC
+
+SL (in chat): probably get other presentation in
+
+RT: question on what are the capabilities, that's hard to answer, there is a whole paper formalizing this, rough intuition as to what that paper does: if I have two different systems A and B working with each other, using stacks/effects/whatever, a nice capability/composability means A can work with B without knowledge of how B uses effect/stacks, likewise for B and A. Paper gives examples of some that break this, and some that don't.
+
+DS: let’s take a quick 5 minute break
+
+#### Typed stack switching update
+
+AR presenting [slides](main/2022/presentations/2022-10-27-rossberg-stack-switching.pdf)
+
+<presentation up to delimited continuations>
+
+TL: what is an undelimited continuation?
+
+AR: good question, typically you will want a delimiter somewhere, undelimited means you can suspend the entire world, throw it away, in practice that's not what you want, at least limited to the boundary of the runtime. In a REPL, you don't want anyone to suspend your REPL and throw it away. So even systems with semantically undelimited continuations have a magic delimiter somewhere.
+
+…
+
+<at option 0 slide>
+
+FM: this is not our choice to make, language implementers choice. Java virtual threads,they are not implementing continuations, they are implementing threads. Java decided not to pass values through suspensions. They are implementing Java.
+
+AR: This is for implementing something new…
+
+FM: virtual threads is a reimplementation of threads
+
+TL: regardless, if we chose to have no values, then Java has to deal with that and pass whatever needed in global state, they could make it work. It doesn't matter what specific languages need as much.
+
+FM: The point I’m trying to make is that this is driven by what the language provider wants
+
+AR: part of a larger project in Java, aiming for providing an explicit continuation interface eventually. Using it for green threads is their first step.
+
+DH: only has continuation interface, implemented threads on top of continuation, no passing of values between continuation context. It's still a delimited continuation.
+
+AR: they gave presentations making clear that they wanted to surface this interface in the future
+
+FM: whether or not Java will do continuations eventually, what they want to do is up to them, not up to us
+
+AR: no disagreements, this is just an example
+
+CW: some analogous restriction might apply to us?
+
+FM: I’m just trying to come up with examples of where these options have actually been used, so they aren’t crazy, even if they aren’t what we actually want.
+
+AR: these are just examples (referring to slides), not necessarily what we need/want to do
+
+…
+
+<at option 1 slide: homogeneous type>
+
+FM: agree with your assessment, parameters are meta level parameters in a sense. e.g. with green threads, things going in and out are green thread related events. In practice they will be fairly stable.
+
+AR: they will be this (functions)
+
+ArjunG: yes in the case of green threads. But in generators they will be values you generated, in actors, in async functions, as well.
+
+AR: we are implementing something in the runtime, sometimes might be an internal value or sometimes a language thing–a mixture of both
+
+…
+
+<on option 2 slide: dynamic types>
+
+AR: I’m not aware of any other system that does this, especially not in the back direction.
+
+RT: Wasm does this already, directly analog of this is call_indirect
+
+AR: no, with call_indirect you check first, then everything is typed
+
+FM: same is true for the third proposal
+
+AR: I read the proposal as: you have a handler when you resume, also a handler when you suspend, you again dispatch. Not that you dispatch once and you know the types, you do it with both directions
+
+FM: not disagreeing with that, just the single-typing aspect. The dispatch is dynamic but when it lands there is no checking–no cast.
+
+AR: whether you call it a check or handler dispatch...
+
+FM: once you have landed at the right handler you know the types
+
+AR: point is, you have to do it again
+
+FM: true, we have a separate justification for that
+
+RT: high-level point is just like what you do to make call_indirect cheap, you can do the same thing here–not a substantial cost.
+
+AR: and you have benchmarked that in what system?
+
+RT: I benchmarked call_indirect and switch on that, we see that Firefox has best implementation of call_indirect because it does that technique
+
+BT: more options coming in further slides?
+
+CW: all else being equal, won't want call_indirect to be the model for how we do switching
+
+RT: why? If not better performance than why do something more?
+
+CW: it's more idiomatic to how the rest of Wasm type system works. Also it’s not clear that it’s not giving us more performance.
+
+RT: don’t presume that it will give you performance… no evaluation suggests that. No reason to say there is performance to this choice.
+
+BT: it’s reasonable to assume that not doing a type check is faster than doing a type check
+
+RT: we can see that engines doing a type check on callee side are more performant
+
+FM: there's an important question here, there is a dispatch, you have to pick the right bit of code to decide what to do, there is no type check, you can call the dispatch a type check.
+
+AR: you can call it a dispatch, there is more you have to do
+
+FM: think both proposals are the same that way
+
+RT: there is something more but I don’t think it is cost; but it gives the freedom to dispatch to many kinds of events, which our use cases often want
+
+AR: separate discussion, but I don't think that's true. But also, when you resume, you need a special entry point to every function which makes things more complex because these functions are now different from everything else
+
+FM: correct in saying that you have to have an entry point to every function, not caused by the event model, caused by the fact that you're creating computation in a suspended state, you have to mingle the first. When you start the function running, you have to give the original values, and the free variables.
+
+AR: we should delve into this, that is a confused view on what should happen; it is just an ordinary function call, I’m not aware of any other system that does things that way
+
+FM: don't have to discuss this now, but this is definitely the motivation for that part of the design
+
+SL: we need to have these discussions, but after AR presents all the options, it will make more sense to those watching
+
+RT: want to correct the claims made in the slides, though
+
+SL: highlight that, then come back to the context
+
+DG: we can put “punt to later” points on a whiteboard
+
+AR: I also have backup slides on these
+
+…
+
+<on option 3 slide: heterogeneous types>
+
+TL: will you explain that more later?
+
+AR: in a backup slide
+
+FM: reason why we have an event on suspend and resume both is that when you resume computation, you also have a similar kind of encoding for what to do when you resume and when you suspend, doing the same kind of dispatch in both cases
+
+AR: philosophically different: this is a function call model (versus the message passing model you proposed)
+
+FM: when you go back to the original high level API, single value from the yield coming back, a unit value. In fact, many cases, you have to return one of the set of possible things
+
+AR: the same is true of function, we could also move to message passing… The main alternative case…
+
+FM: why not do the same for suspend and resume, why special case?
+
+AR: no special case, I think it is natural. The second result is an error or … Why invent something new when we already have, e.g., exceptions?
+
+BT: for chain of suspended resumes, R is always the same here, is it possible to relax it? where the R changes?
+
+AR: that wouldn’t make sense
+
+BT: you need to handle the event that comes back, each of them are typed, can they receive a different R?
+
+AR: R is this type; handler can’t change what the computation returns
+
+AG: first B->R, doesn't know for a fact that the second or third handler will want to be called, has to be prepared for just the first event firing, without getting into more complicated type system machinery.
+
+AR: maybe the picture is confusing, the type R is not determined by the handler, it is given to the handler
+
+BT: but a value comes back in the event, the handle to the continuation
+
+AR: handler can't choose the type, it is given that
+
+DH: there is a way to change the type, called a shallow handler in the literature, can do powerful things with that, unclear if we can implement that efficiently. The thing we have here is called a sheep handler (shallow + deep)? nasty implementation if you want a true shallow handler. In this scheme you always have delimiter in the stack.
+
+JM: general comment, it’s hard to follow the discussion about specific details. AR has gone to a lot work to present the details here, I really appreciate that and want to finish understanding this before we discuss the philosophical questions
+
+…
+
+<on “topology of stacks and handlers” slide>
+
+DG: in the part with a separate stack, is that a result of a previous suspension?
+
+AR: it is a result of creating another stack, you previously suspended, then created another one
+
+PP: arrows are stack frames? creations of stacks? what do they represent?
+
+AR: when you resume, in the implementation each box is a stack and each stack knows its parent. They need to know for various reasons, e.g., exceptions.
+
+PP: basically stacks what we have now, and...
+
+AR: stack of stacks yea
+
+PP: resume at the very end, you're pointing to the one that is started? you point to the lower blue box? why not have two arrows point to the top box?
+
+AR: there must be a linear chain, semantically the current stack is a list of these stacks–not a tree
+
+BT: meta comment, find these diagrams a million times easier to understand than code, i understand now why R must be the same, when you fall off the stack
+
+AR: I have more diagrams!
+
+FM: arrows really should be pointing in the other directions
+
+AR: they are directed but can be interpreted either way
+
+…
+
+<on topology of stacks and handlers slide, more complex example>
+
+AR: maybe this is surprising or controversial, but in all these semantics and proposals, what we really have here is dynamic scoping.
+
+FM: there are systems where that funny suspends would be legal, you are choosing to mark them as illegal
+
+AR: when you suspend you go to the thing below
+
+FM: you have to make sure you know where you are going
+
+CW: isn't this exactly the distinction between delimited and undelimited
+
+AR: no
+
+SL: clarification here, CW's question is on point. If you have undelimited, no boxes connected by arrows, just a big collection of boxes, FM would be right, it will be legal to switch between all the single boxes, doesn't make much sense in a system based on structured concurrency or delimited continuations
+
+AR: in such a system you would draw the arrows differently
+
+AG: suspending is not switching to another computation, that's what resuming, suspending takes you to another handler, do whatever work is required, when you resume, you resume what's suspended
+
+AR: well, when you suspend the handler computes on the stack below it
+
+RT: earlier, you said primitives were suspend and resume, natively, the primitive is switch, what I'm trying to figure out is switch, all these things compile down to that instruction.
+
+AR: it is “switch” as long as you don’t care about being structured, which becomes undelimited continuations, which we can’t do in structured continuations
+
+RT: will save this for later, provided you don't make the claims you are making now, the native thing is switch, if we can find a way to make switch way that makes nice composability properties, then it is a great solution
+
+AR: to add to the point, why we need dynamic scoping in all cases, must find the binding point for that name
+
+RT: having it be a check v.s. having a choice, is critical for composability properties, they are not the same thing
+
+AR: they are pretty much the same thing; no cost difference, both are a linear search–must pay that cost. Basically the only difference is in the search criteria.
+But this is an area of disagreement.
+
+…
+
+<on “option 2b: by stack reference” slide>
+
+FM: on web, something like this happens already, the resumer of the promise is not the same as the computation that started it, the microtask runner, different computation that is resuming your computation
+
+AR: that is the case for many of these abstractions
+
+FM: this thing happens anyway, in the case of the web, there is no original computation, it's all gone, by the time you resume, original computation has disappeared.
+
+AG: probably don’t understand about this style of proposal; in a structured approach you can only suspend to handlers on your current stack, right?
+
+AR: you have to select which one in the scope, FM's proposal selects it by reference. instead of a prompt name, you take it by reference.
+
+AG: by reference to the handler…
+
+daanx: like exception, you specify which exception handler you go to; might be inconvenient.
+
+BT: exactly what I was going to ask, handlers that can handle the same event type, the type isn’t enough to uniquely identify the handler.
+
+FM: stack reference approach, whoever last resumed me is responsible for handling my suspension, from this point. at this particular point, whoever resumed me is responsible.
+
+AR: exactly what is happening here
+
+FM: reason for that is, that identifier is stable, other identifier is not, the downside of using exception handling approach is accidental capture, may through exception that is caught by the wrong handler
+
+SL: show this example first before debating it?
+
+…
+
+<on “option 3b: by handler label set“ slide>
+
+CW: if i'm in the top most blue box, and suspending D, is it the case that i have to walk all the black arrows to find it
+
+AR: the second: all are dynamically scoped, all need to walk the stack
+
+CW: we just saw an example where you are handed the reference directly 
+
+AR: but we still need to check that the reference is in scope to validate it
+
+TL: can’t we do this in constant time?
+
+LW: not for lack of trying by many people
+
+RT: semantically, you can name a target. in your example, you have 2 B, name one specific B, with lexically scope thing
+
+CW: question of accidental capture right?
+
+RT: lexically scoped with dynamically scope check, switch target is determined by lexical scope
+
+CW: generative labels remove this distinction?
+
+RT: first class labels can get rid of it, you are recreating the same thing. A thing to think about, you can decompose option 3b into 2 steps, 1 is do a search for target, 2 is switch to that part.
+
+DanL: in a language like Koka with rich type system, I can guarantee it is in dynamic scope, no dynamic check needed, there it can do things in constant time, translated to Wasm, you lose the rich type system like effect typing, in those cases, it needs the dynamic check, has to walk those arrows.
+
+BT: want to double-check understanding: labels are event decorations with types, e.g., type R attached to label D, right?
+
+FM: need to push back on something, I don't support this point in the design space, if you have the extremely unconnected set, there is no search, if you have a suspended computation, engine will trust that you are allowed to do it, the search/validation is only because we are stacking the stacks, if we didn't do that, we won't need to do that validation
+
+RT: I figured out how to get rid of that, not worth focusing on
+
+AR: if we didn't stack stacks there wouldn’t be a way to …
+
+RT: figured out in a way that satisfies the strong abstraction theorem
+
+JM: in all the proposals, it is the case that the call that we do is not known statically, like an indirect call. all dynamic scope...
+
+RT: there is no dynamic search! There is a validation check, is that target a valid target, which I know how to get rid of, you specifically name a search
+
+CW: the distinction is either linear search to check you’re jumping to a safe place, or linear search to find where you’re jumping to
+
+JM: is it always linear? can be amortized?
+
+BT: like stack unwinding…
+
+LW: compilation strategy, force you to not stack too deeply
+
+RT: I have a writeup somewhere that shows how runtimes can make it a constant-time check
+
+AR: a lot of people will be curious to see that
+
+RT: would love to get to it
+    
+<break for lunch>
+
+AR: Going to skip most of the rest of the slides
+
+AR: Direct switch: bypass one hop - compatible/orthogonal with other choices, more complex than other primitives – undermines structure because bypass handler? So maybe it should be Opt-in? But Unclear benefits and Needs experimentation. Maybe post-MVP?
+
+AR: Other considerations: memory management. I agree that we don't want GC dependence. Fibers allows for heap cycles so needs GC.
+
+RT: That's worth discussing. Maybe later?
+
+FM: there’s an independent question, which is whether a computation is allowed to be GCed. My thinking has evolved on this; originally, I thought it was obviously yes. But I don't think so anymore. WRT cycles, you don’t need fibers to get cycles.
+
+RT: Bigger thing is, what does it mean for an app to need garbage collection. Many embedders would be fine with reference counting. Fiber.release is for explicitly releasing. Question for non-Web people is whether it is ok to have a max number of fibers. 
+
+LW: wondering about this from the wasm time perspective. Could you end up with an app that implicitly depends on collection of cycles because it’s only tested against host runtimes that do collect those. But then it crashes when there’s a limit. I’m thinking it would be good to have portable semantics that says they are definitely collected or not. Then you can have determinism. Some languages collect blocked fibers some don’t. 
+
+RT: Another thought is everyone in non-GC world will be using a uniformly typed table of these things. If they don't remove a reference, it will just sit in the table and not be GCed anyway.
+
+LW: That’s an assumption of how you lay out your tables.
+
+CW: Does the typed continuations proposal not have this problem? What would you add to typed continuations that would cause these cycles?
+
+AR: Has heard very different answers about whether people care about this. Felt the temperature of the room was it shouldn’t depend on GC.
+
+FM: GC used to be a simple question, but now it's clear we're going to have it. If you have a language that doesn't use WasmGC but transitively depends on it via some other feature, that's a nightmare.
+
+AR: Thinks there are implementations of wasm that won’t have GC
+The reason you face the GC problem is if you care about cleaning up failed/abandoned runs.
+
+JM: Why can’t you clean up without GC? 
+
+AR: They are first class. You can pass them out of the module.
+
+JM: So there's an implicit cost for externalizing these fibers?
+
+AR: heap allocated things are not really owned by  modules. They can be passed around, and don’t need to be associated with a particular module, and can outlive them
+
+CW: Should be able to pass a fiber without needing to do anything on the boundary.
+
+JM: for function references today, you have to say they’re externalized, in this case I can’t say whether it is or not for the module
+
+AR: It’s a bit of fuzzy distinction. Function modules are treated at second class. Stacks are treated as first class. In reality, where you dynamically load modules you still have this problem.
+
+JM: anything that has a handler now would have to expect that handler could be called from any other module, and restore and VM state from that module?
+
+AR: No, modules don’t have a semantic meaning.
+
+JM: And functions that aren't exported still participate fully in this?
+
+AR: yes
+
+FM: If you have mutable references that you store a continuation in, then you must have cycles that need GC.
+
+DH: no, it’s not possible.
+
+FM: there are use cases where you need it.
+
+RT: Your supposition is if you have mutable references, AR’s is that if you don’t have mutable references then you don’t have cycles
+
+AR: if you have a mutable reference on the heap you have already bought into GC
+
+FM: with JSPI you must have mutable references on the heap
+
+AR: stacks are nulled out once you enter them, so you don’t end up with cycles
+
+AK: Let's write this down and discuss later.
+
+AR: really depends on how you implement continuations. You now have a choice. If you have GC you can have cycles. If not, you have to avoid cycles. WIth this proposal you have a choice?
+
+RT: For lots of settings, the surface-level language has some mutable reasoning about continuations, If they don’t use GC, then they will store these references in tables or globals, so irresponsible applications will leak them.
+
+AR: Scenario we care about is one without GC. 
+
+RT: i can make a continuation that makes another, etc etc i can get memory leaks through other means anyway. So all the engines will have to limit applications on how much continuation/fiber space they use, and irresponsible applications will suffer.
+
+AR: The point is what is on the slide. If the engine knows the module is dead can it do anything.
+
+FM: With respect to the fibers proposal, you don't need to invoke cycles to point to a problem. When a fiber is finished and returns, there's still a question of what to do with the reference to the fiber. So there's a problem even without cycles. There's another version of the fibers proposals without first class fibers that keeps them all on the table.
+
+AR: You have table get, what does that give you
+
+FM: It would be disallowed. In that world there would be no need for GC.
+
+RT: Would like to hear from other people in the room, who we don’t always get to hear from
+
+AR: When you return from a continuation that’s where you dereference.
+
+HA: What are the major representative use cases that are addressed by the fiber proposal that are not addressed by the typed continuations proposal?
+
+RT: Would like to save the question for later.
+
+AR: Many assumption, little evidence. Need to converge. Trying to take cues from what others have done in the field. In other languages we have data points, but not much in Wasm. Have some open questions. How easy is this proposal to target? thinks it will be easier than Francis’ proposal.
+
+CW: at a high level do you have a plan for taking examples and looking at them both in fibers and continuations, and justifying your beliefs?
+
+AR: We have several ideas. Daniel talked about them on Tuesday.
+
+DH: we have multiple plans for implementations, both in terms of languages and implementation strategy.
+
+AR: Not just on the consumer side, but also on the producer side as well, right?
+
+DH: Right.
+
+JM: Would love to discuss the implicit overheads here such as implicitly exported functions and costs for code that doesn't use the new mechanism.
+
+AR: Agrees, very careful to design the proposal. Should be zero overhead.
+
+RT: can i request that we take down the slides so i can see the room
+
+BT: Looking forward to the experimental phase. Looks like the lay of the land is that one proposal will be implemented in one system and another proposal in another system.
+
+SL: Would like to try both proposals. They're not that different and the interesting differences will be in the underlying implementations strategies like segmented stacks.
+
+FM: Would like to dig deeper into the question of experiments. When doing scientific exp you have to figure out up front what you’re trying to measure. Some versions need an implementation, some don’t. V8 is more difficult. Just implement this in WABT and you’d be done. Would like to be more careful about the exp.
+
+RT: We’ve spoken a lot of implementors of these features. When you boil everything down, what is the key operation you do to use this. Everyone, including ocaml, has said this lowers down into a switch. Has been working on a way to make that the only operation. Find the fiber you want to switch to and switch??. This looks most like un-delimited continuations. Has been working on feedback from Thomas. Trying to make a composable way that has the nice properties of the paper. Would like to get to a point where we could implement this.
+
+AR: i actually think no, that would not be easiest to use because people would have to deal with dangling exceptions and things themselves.
+
+TL: presumably toolchains will arrange to not have dangling exceptions
+
+AR: On the producer side
+
+RT: for example, take delimited continuations. We talked about how they are basically a linked list of stacks. How they are implemented is, when the stack returns, when you get to the top frame of the stack in the low level runtimes, that top frame says I need to return this value. I have somewhere in my data structure a parent stack, i will switch to that with a value. Similarly if an exception propagates up, they switch to the other stack, so even those low level systems boil down to just a switch. Their existing implementations could be reused.
+
+TL: You’re saying toolchains would be responsible for implementing the policy of where to propagate exceptions or other transfers
+
+RT: Yes. And there are languages that have policies that don’t simply go up the stack, that don’t mirror the dynamic stack, so giving languages more flexibility is good for wasm
+
+BT: about the abstraction level: there's advantages and disadvantages to reductionist approach, it may be hard with a low level semantics. Wasm has been successful by being not the lowest possible level, but one level above that. You can make more optimizations, more guarantees from type system, more structured, certain errors can’t happen, so there is a tradeoff and you get benefits from being a bit above the lowest level
+
+SL: I was interested in what you meant, Ross, when you said that other systems with delimited control end up taking switch as their primitive. I don’t think that’s the case; at least I don't think they would describe it like that.
+
+RT: i had a meeting with KC about this, a year and a half ago where we walked through how multicore ocaml is implemented and indeed theres a stack switch at some point.
+
+SL: yes but that’s not how they factor the code. They have an API that’s more like resuming and suspending in the manner that Andreas was talking about.
+
+RT: At the surface level ocaml doesn’t have this. There’s a big distinction here. Trying to mirror Wasm to all languages will severely limit what can be done.
+
+SL: Absolutely and that's not what I was talking about.
+
+DG: Maybe we can talk the native switch discussion offline. Do the participants have any questions for the proposal champions? Picture of what to be discussed is in the notes.
+
+CW: Ross, the design you laid out there seems to break from the spirit of both of the existing proposals. Do you think we should open up the discussion to this third direction?
+
+FM: Doesn’t think there’s a kumbaya moment today. 
+
+CW: but are we working towards a synthesis of the 2 proposals?
+
+
+FM: thats the idea but there are decision points that point in different directions. I was hoping to come out of today with a list of those that we can work from. If we try to go down the list today we don't have enough time to do it in a meaningful way
+
+DG: As a follow up to that. To the people in the room, is there anything you’d like to ask the champions?
+
+RH: theres a lot of things on the whiteboard. The biggest thing from my perspective as an implementer is that i want to understand the implications of this. One question about the fibers proposal. When you're doing a resume to a fiber there can be several possible events that you're sending in the resume. 
+When you're on the side executing the resume there's going to be a switch. How do you find the destination? It seems like you'll have to do a search of possible handlers.
+
+FM: You do have to do a branch. The governor of the branch is the event tag. And so you can arrange for a perfect hash. You’d have to execute a perfect hash on the event tag. 
+
+RH: when I hear “perfect hash” does that require that you have all the modules known?
+
+FM: no the hash will be executed by the receiving code.
+
+RT: Both proposals have event dispatching, so this is not specific to either proposal. You can take the typed proposal as having a single allowed event at a particular point, so the first one you search for will always be the right one. Shouldn't be a performance difference.
+
+RH: evaluating performance is just difficult because you could e.g. have a perfectly predicted branch, and things that look linear could be really cheap or really expensive, so i’m just trying to figure out where there’s magic and what’s hard.
+
+SL: It might be worth pointing out that it’s the same thing you do with exceptions. If you know you’re only dealing with a  fixed amount of exceptions you can optimize that. If you have them on the stack you can just look at the label.
+
+RT: a variation i considered was, if you imagine a table of handlers you could say you expect at index 2 of this table, a particular tag, and you only check that. It limits your expressiveness but maybe that expressiveness is not needed.
+
+FM: It might be worth sharing some intuition. When we've been looking at the implementation of switching in V8, there are these informal numbers we hope to achieve for the relative cost of switching and other operations. Switching between tasks is probably going to cost about 5 function calls. If it's 10 function calls then it's 5 too many. Creating continuation is going to be around 20 function calls because of the allocation.
+
+RH: The other implementation perspective I have is a concern about starting a fiber with multiple entry points for different events.
+
+RT: Francis and I have been iterating on a way to get rid of that.
+
+LW: Curious if anyone is versed in CFI and knows whether there will be problems here.
+
+FM: I don't think there's a difference between the two proposals on that. The biggest problem is going to be on Windows.
+
+PP: Dynamically optimized languages, in particular JS already break CFI by default, for example by substituting return addresses. That’s why stack switching in Wasm would not make JS runtimes more CFI-compliant. The story can be different for standalone runtimes.
+
+LW: Definitely you're both thinking about how this gets implemented on Windows CFI. What are the primitives?
+
+DS: They're very OS and architecture- dependent.
+
+RW: We’ve been working on that with Intel CET as well 
+
+PP: There are 2 major approaches; one is pointer signing, that’s what ARM uses. And shadow stacks and landingpad instructions; that’s what x86 uses. Intel supports both and AMD supports a subset at the moment. Windows has a software based replacement for landingpad instructions for indirect branches.
+
+CW: Eventually trying to synthesize both proposals, what I would like to see is that we get to the heart of the issues that people care about. The proposals have also made different cosmetic decisions such as handler blocks or branches. Can we boil things down to the essential issues.
+
+FM: You pick up a thead and you follow it up and you end up in a different location.
+
+CW: I think the main issues will be accidental capture and the GC question.
+
+FM: The smaller the issue the more argumentation there is. Having a list of things we disagree on would be useful.
+
+CW: diff between proposals right now that are not on that list
+
+FM: yes true
+
+SL: I am one of the co-champions. We’ve been talking about “two proposals”. We’re not really talking about two. Talking about a typed continuation proposal which has been fixed for a while. The fibers have had several proposals. It’s hard to nail down which proposal is suggested.
+
+TL: for a phase 1 proposal, having a lot of changes is healthy
+
+RT: we are getting feedback from people who want to target this and incorporating it
+
+DG: two ideological differences, can count them as proposals, in the interest of time, hoping to cap the discussion now, iterate on the list (on whiteboard) more, figure out a way offline to have a discussion some weeks from now to figure out what to do.
+
+DS: if we cannot converge, wonder if we could agree on what should be in the list
+
+CW: If I could make a point of observation. I see the typed proposal as more polished in ways that are orthogonal to the things people actually disagree about. Would like to get to a place where the disagreements are expressed as only the bare minimum thing changing. Have this conversation in a way that’s not going in a million ways at once.
+
+SL (chat): I agree with Conrad
+
+AR: I have to emphasize what Sam said. We have spent a considerable amount of time considering all the versions of the fibers proposal. This is not a good use of our time.
+
+CW: have to get FM to agree with you that you can tweak the typed proposals to get to the design space you outlined in the presentation
+
+BT: A year and a half ago we had a schism in GC and we got through it by experimentation but also by threatening to ship the union of both proposals. We need apples-to-apples comparisons, so would you be able to implement both in the same system?
+
+CW: I would have an opposite position here. Thinks there are valid design decisions here before implementing.
+
+BT: you have duelling threats
+
+– break –
+
+#### Follow up session: [Relaxed SIMD](https://github.com/WebAssembly/relaxed-simd/) + phase 4 poll(?) 
+
+MD presenting [slides](https://docs.google.com/presentation/d/1OPfEwQU7Mp8CCjHc0VMaeipIjNRyLK5Oius0F58yPO8/edit?usp=sharing)
+
+DGman: GCC and Clang implement contraction because the source language lets them, but that information is lost by the time we get to Wasm.
+
+MD: fair, for many applications written in C and C++, little difference whether contraction happens in Wasm or source langauge
+
+DGman: Do we have data on that? Seems you could contract more things since you aren’t limited by semi-colons.
+
+MD: we can contract less things than C/C++, because user exactly specify where this contraction can happen, in C++, compiler can find any combination of mul and add and fuse it together.
+
+AR: w.r.t. fingerprinting, one strategy you might use is that if it doesn't have to produce the same output, it can randomize that. It makes fingerprinting harder, when you have to make it reproducible, you're taking away that option.
+
+MD: danger here is that different Wasm engines randomize it differently
+
+AR: depends on how good your randomization is. Is more entropy better fingerprinting?
+
+MD: if we allow different lowering depending on context, that will enable identifying the different engines
+
+CW: As Deepti has been brought up. Need to be careful about what the spec allows and what engines will do to resist fingerprinting.
+
+JM: What if you just trap instead of having a slow version of instructions in the arch-testing suggesting?
+
+MD: haven't considered, looks better than slow emulation, still have the issue of writing separate implementation for different hardware
+
+CW: having an instruction that non-det traps is not something i want to see
+
+DeeptiG: +1 to that. Really challenging for developers. Easy to debug but not the best experience.
+
+JM: actually sounds wonderful, this is only for experienced developers who know what they are doing, the consequence is that the user is using this, and library is doing it wrong, then i can see the library is not handling the case. better outcome when one case is much slower. can imagine a world where most people use 1 arch and the other arch are slow because no one wrote fast code for that path.
+
+RH: Can the "is_fma_supported" instruction be nondeterministic or does it have to be fixed on a host?
+
+MD: would be deterministic, the point is to completely remove non-det
+
+RH: seems like you're shifting the non-det to that instruction
+
+MD: fair statement
+
+BT: Regarding the trap, that's only what the Wasm instruction does, but you can always branch and have the userland code do the difficult emulation. Also, I don't think there is much of a code bloat concern since this code will be very small and centralized.
+
+CW: think we should be clear that we are not currently in the proposal, expecting that people will emulate FMA, this is a speculation
+
+Deepti: These should all be treated as suggestions, they are not in the spec, I just want to make that really visible so we're not spending too much time on one of these suggestions or the other.
+
+CWoods: we would expose the ability to check if FMA is supported, then developer can do the intrinsics, or write their own code path?
+
+MD: the suggestion is to directly expose whether some of this extra platform specific instructions are supported, and expose them as instructions, potentially this instruction will trap on systems that don't support it. It forces developers to write platform specific code. Original purpose is to make it possible to write portable code with some constraints, for most applications, they work well with the constraints.
+
+CWoods: This approach is roughly what happens now. If you want to use hardware features, you write application-specific code and hide it in a library.
+
+BT: on portability, it's maybe different definitions of portability, you're expecting the code is for in bounds input, there is a detection case for out of bounds. we're in an area where people are on the edge of portability
+
+MD: to large extent, what is our main use case, people writing portable code? or non-portable code. This proposal targets writing portable code.
+
+CWatt: Would like to see next slide.
+
+(Next slide is a poll)
+
+DeeptiG: highlight this from Chromium perspective is that, we saw some performance numbers, not the only potential performance, lots of enablers on top of XNNPack, like Tensorflow, also evidence from Text-To-Speech, that FMA is compelling to have for performance reason, philosophical reason here when you have good performance data. What is an acceptable solution here so that we are not holding performance back?
+
+CWatt: My perspective is that the final version of the proposal that was landed on is as good as it can get and any further questions about how we protect the spec from nondeterminism can be addressed as we write the formal spec.
+
+SC: I thought phase 4 meant we were done writing the spec.
+
+CW: We have a formal spec. This is all editorial.
+
+DeeptiG: 3 prongs to this discussion, determinism, do all instructions have deterministic fall-back? One part of it is implementation defined behavior, because of what the usage patterns are. Spec concern as CW summarized. Is there anything else?
+
+JM: Semantically, about the meaning of phase 4, that would mean that none of the suggestions you presented would be adopted?
+
+CWatt: Yes. I think the point of that presentation was to show that all of the suggestions have been considered and discussed.
+
+TL: outcome of that discussion is that, probably what we have in the proposal now is the best way forward
+
+CW: or at least the least worst way
+
+LW: interest exploring different ideas, in an ideal world, if hardware can be implemented instantly, just add instruction exactly what hardware does, tomorrow we can have both on both CPUs. What about if we have an instruction that does what you want, you can find out non-det if it traps or if slows (ignoring that), the target world we want is when you have all of that. Because today we want canonical scenarios here. When you do, you have all of them, it could be really slow. But it is completely deterministic. Incentive people to move towards the world where all instructions implemented everywhere.
+
+DGman: IIUC, the FMA is either FMA or a mul and add…
+
+BT: basically we should spec the union, always do the same thing everywhere, and do emulation
+
+LW: non-det ask if it is fast, as everyone move towards this common target state where all of them fast, and non-det move towards there. It is not an option it is not fast. The test is fused to a branch. We can plan our own deprecation path. Still allows us to be fast today.
+
+BT: even if you didn't have non-det ask if it is fast, you can measure it. If it is obviously faster, that's what you want to use.
+
+TL: we are talking about getting rid of non-det in the spec by speccing the union. But forcing all the applications to write platform specific code because they need to do this test.
+
+BT: if/else which is good
+
+TL: portable code is nice too.
+
+CW: do you think we need to introduce this now, or later? E.g. imagine this proposal goes to phase 4 as it is now, if another proposal comes along, is single rounding fma fast, if this returns 1, then qfma that is already specced and is fast, does that order of things work out?
+
+LW: trying to think if it is backwards compatible, in the short term instructions are non-det, in the future you can do a check. If you wrote code in the old way, it won't be what you want.
+
+DeeptiG: would be a nightmare to support, from engine perspective, the old way and new way, and old way works better. We want to say realistically, if we were going to detect if we were fast, what would it look like, is that a hint?
+
+RT: 2 threads, one of which does one and another does another version, that will get you what is currently in the proposal.
+
+DeeptiG: very limited form of non-det, can expect engines and applications
+
+RT: pointing out the philosophical, time and performance are observable things
+
+CWatt: I think this is an interesting thought exp, but we should table that for this proposal.
+
+MD: present another argument, if we have deterministic variant of all lowerings, will it still be helpful to have relaxed instructions, would it be helpful to have relaxed isntructions, will be helpful to write code portable to different cases? yes
+
+JM: if we are in this world where I am explicitly saying, Engine trust me, it is because i ran my applications and said that using the thing that is stable is not sufficient. If i am explicitly saying I am using this performance, it is a compatibility bug that i don't get the performance.
+
+BT: I was being only half-facetious when I proposed if-else. The relaxed SIMD instructions are essentially macros around an if-else.
+
+CW: This proposal is already biasing towards always doing the fast thing. 
+
+BT: about portability thing, the relaxed thing is this 5 instructions, if/else, that's the portable SIMD
+
+DGman: Why was the reference lowering of FMA multiple + add?
+
+MD: no FMA in Wasm, we specify it in terms of Wasm SIMD
+
+DGman: if we say that ref interpretation is the good version, then that will be better for this evolution process, we will converge to the good version. The only thing blocking that is that we don't have an FMA?
+
+BT: in SIMD, we spec the intersection, with a few changes. Now this is the place to explore speccing the union, you want the machine instruction that is there. SIMD has this problem, if you really want to implement the spec, emulate SIMD in software. Until you get to profiles you have to emulate SIMD with software. This is just another thing you have to emulate if you want the spec.
+
+Deepti: How many people feel comfortable voting for phase 4?, almost there if we can include an FMA, what would make the room comfortable about speccing this?
+
+CW: as much as it pains me to say this, if we are bargaining over last second additions.
+
+Deepti: read this as, we are kind of there, but not really there
+
+CW: either we go with something that basically look like this spec, having primitives that are fast but wobbly in terms of det, we go in a different direction, det instruction but trap if not in hardware. That seems to be the 2 paths.
+
+DGman: I think part of what you’re seeing is brainstorming on the fly. I think we should be more prepared. I think X? Made a good point about determinism. I don’t see the trapping solution as a good solution. Can we find a path in the future where we can get rid of this? FFM is one of the most important parts of this, can we get to that.
+
+BT: whose responsibility is where the cost ends up? as it is currently specced, the cost is a new kind of non-det in the spec, lots of people uncomfortable with. We are shifting the cost around, we can't get to a zero cost, ruining the spec thing is forever.
+
+DG: propose something in the interest of time, able to attend the subgroup meeting tomorrow at 9am. Continue this in a small group
+
+CW: if the test of whether this proposal is a good one is whether we can go towards the future, the current proposal, we can narrow the spec that double rounding behavior is no longer around.
+
+ #### Memory64 update 30 mins (Sam Clegg)
+
+SC: Ben has raised the issue that we might want to use a bit in the load and store instructions to say whether the referenced memory will be 64-bit or not.
+
+BT: super minor issue, don't feel very strongly, ways around it, e.g. tagging memory, it will be in the flags byte, bit has to be set if it is loading form memory64
+
+RH: has a flag, then a bit indicating if loading from 64
+
+AR: what about instructions that don't have this, memory.copy blah?
+
+SC: presumably not performance critical and interpreter can look up
+
+BT: not such a big deal..
+
+RH: how many bits available on the flag?
+
+SC: Haven't looked closely enough. 6 bits for alignment.
+
+AR: can use any bits for the alignment, re use it for alignment initially, then use it as bit field, can reinterpet it in various ways, harder proper are the other memory instructions
+
+#### WebAssembly roadmap
+BT: Open discussion. We've had a mix of proposals making progress and getting into drawn out arguments. Both are great. I've seen dysfunctional subgroups become functional and make progress, so I'm optimistic. We've come a long way from just trying to ship C++ on the Web. Lots of open questions. We have the CG chairs here.
+
+DGman: What would be the process for changing the phase process to get rid of that "usually?"
+
+CWatt: Consensus
+
+DGman: Can we fix that now?
+
+CWatt: Would want to get it written up and fix other things at the same time.
+
+FM: One thing the group should consider is space for working around the uses of Wasm. Wasi is a interesting effort around this. API + ?? . When I was working at OMG on CORBA and UML there was a split effort around this. Expanding out besides the technical parts. 
+
+The nontechnical parts of OMG were way better attended than the technical parts.
+
+DeeptiG: WebAssembly Summit, Wasm Day at Kubecon(??), etc. are community events. How would you envision this space?
+
+FM: SO going back to OMG, these other activities were not informal. There was a standardization process for medical terms. Doctors wanted a standard way to describe how people could be killed. It was like UML in the broader scope, but not directly the same.
+
+CWatt: One thing that may be related. I have felt that we’ve reached the end of our useful knowledge of paint points (in threads context). We need a process of hearing feedback from users so we can re-pollinate.
+
+DeeptiG: There's a standard way that other Web standards do this, which is generally gathering at TPAC.
+
+AC: There's a perception that ??? doesn't matter unless you're in the bytecode alliance and then it doesn't matter unless you're Rust. There's not a lot of outreach beyond those efforts. One shift would be to actively own more of the ecosystem or at least do more liaising to other ecosystems.
+
+BT: Some of our customers have been other language implementers. This has been more adhoc. Would like to have shared notes to hear about what they’re having pain points with.
+
+AC: Yeah, and I think this could be not necessarily a state of the union type of thing, but to talk to some of these folks. A lot of this work goes far back and isn't very approachable. Adoption lags behind by multiple years in cases. One thing I posted an issue about was on the web site adding more non-browser feature support.
+
+Deepti: Not a full response, but would like to highlight that community efforts take a lot of commitment and time. There are a lot of people from various groups here. Wondering if we could scope it down to what really need maintenance. Things like the website.
+
+CWatt: I would also like to make a specific point that I hope very much that we can do some top-down solicitation of feedback.
+
+LW: Thought Francis did good work bringing in feedback from a lot of languages. Would be nice to bring others into the meetings to have them present or share to learn more.
+
+Nabeel: As an application developer, we really appreciate the work that has been done here. We're always happy to try new features and push the platform forward. If there were a public place to share, we could share a lot more. It would be good to have a public roadmap, since we get a lot of questions about when things will be ready.
+
+RH: At the risk of derailing this. The meeting cadence is every other week and there are subgroup meetings. Are there any feelings that the meetings are too long or too short? Hopes to continue doing in person meetings. Thanks google for sponsoring.
+
+AR: As someone living in Europe and attending many of these meetings, most of my week evenings are taken up. Would love to be able to decrease the frequency of those.
+
+BT: Also spent time in APAC, meeting times were very difficult. 
+
+Derek: There’s not one time that works. We tried alternating meetings.
+
+AC: If a goal is to be better async with less meetings, then there could be more rigor in how we do spec tests. Specifically they're often lacking any comments whatsoever about the intent or anything like that. Doing better here could reduce churn on issues and decrease frustration.
+
+CWatt: If we want to be serious about async communications, we could do better than GitHub comment threads, which are append-only. We get into cycles of repeating the same positions over and over.
+
+AC: Also meeting people where they are. Fairly easy for Go folks to get on chat there. Easy way to feel more engaged. Can jump into channels and get more involved.  
+
+CWatt: Some groups have started doing virtual office hours.
+
+AC: Yeah.
+
+Deepti: As a concrete step for meeting times. We could send out a form and collect responses about how schedule meetings. Would like the engagement to be more organic. Have local specific groups. Should bias towards where the engagement is organic. Having tried to do this before, it was not great having now one show up for meetings for an extended period of time.
+
+AK: I wanted to come back to roadmap a little bit. I heard Nabeel say it would be nice to have a picture of where things are. It's harder for me to see what that looks like today. I can see what browsers are doing with GC and what bytecode alliance is doing with the component model, and there's SIMD work as well. What do folks want when they say they want a roadmap?
+
+Cwatt: Run out of opinions from users. Need to spend more time collecting users feedback.
+
+Nabeel: Information about dependencies between proposals would be helpful.
+
+AK: Having done planning within wasm within google. It would be great if we could agree as a group that what we are going to accomplish, but this doesn’t sound reasonable. What was BT hoping to get out of this.
+
+BT: Yeah, we were chatting a bit about this at lunch. Hope springs eternal. Wasm 2.0 penetrated the public consciousness and there will be a 3.0.
+
+Cwatt: We should be more ambitious about planning.
+
+AR: One questions is who owns PR and the horribly outdated web page specifically.
+
+Deepti: The website is open source and anyone can work on it. We’ve tried to update, but lack people to keep it up to date. Would like it if everyone was empowered to update the site.
+
+AR: Shared responsibility is no responsibility.
+
+RH: The things that are most important are those that increase adoption in the browser (because that's what I'm paid to care about). For C++ and Rust, it seems like they're in a good place with features, so we need new languages. But it's a winding road without a specific language to work on. A roadmap could take that into account.
+
+AR: We could try to do a public survey, but these things probably don’t work well.
+
+BT: Languages usually come, but slightly broken. They come broken, but we have to listen to feedback and help. Need to do more engagement like Francis did with language implementors. Eventually we can get them running.
+
+FM: I find that having customers come to you explaining their experience in their terms is really powerful for any engineering group. It's a good idea to do more of it.
+
+RT: We talked about how we reached out to a bunch of teams for stack switching. As of yet, not a single person's feedback has changed anything. Generally their feedback gets dropped. It's something we need to fix.
+
+CWatt: I agree that we need to solicit feedback in a structured way that we can actually take action on.
+
+AC: There are things that pile on over time. There are recent frustrations from language developers, for example on the GitHub issue on goto. It would be good to go back to some of those issues and solve some of those problems.
+
+Cwatt: Totally on board with GOTO. 
+
+AC: It would send a big message.
+
+CWatt: Is there some kind of forum to solicit feedback.
+
+BT: Should cycle back on these threads.
+
+AR: Pushing some of these things forwards requires work. The work is not magically coming from somewhere.
+
+CWatt: It requires work and a justification for why they're going to do the work. We need a structured set of voices saying they need these.
+
+Deepti: Some part of this is a solved problem. Open source projects have been doing this. Just tagging these issues is a good way. Being better about our issue management could improve this. Some way to invite others to help out with us.
+
+BT: Before shipping MVP we burned down the issue list. Closed things not relevant. Should go through issues and have an official response.
+
+DeeptiG: We do this for some proposals that are close to shipping.
+
+AR: The problem in general is not that we decide not to do this. In general, how do we prioritize? There are many features I’d like to see, but I dont have the capacity. I don’t know how we can fix this problem.
+
+CWatt: I also want to acknowledge that for many things people would want, such as goto, the bottleneck is implementation resources in engines. And the implementers are already oversubscribed.
+
+BT: Should not work twice as hard we all work really hard. Unless you subscribe to all the repos there’s no way of knowing what the priorities. I tweeted about some GC work and that’s how people can here about work. There’s no organized view of priorities.
+
+AR: There's the list of proposals, which is kind of the closest thing we have.
+
+DS: That was made by someone outside this room and we might not have thought of it. We don't know what we're missing.
+
+AK: We keep jumping around this issue. There’s some work to do, but we all have a lots of other work. There are other ways that do this, people pay into an organization that does the work. This sounds scary. This may be bytecode alliance. Luke how does this work?
+
+LW: The centralized part of the bytecode alliance is still booting up for similar reasons. Everyone is busy with their open source software rather than booting up the org. Could have some sort of subgroup meetings to discuss website problems and assign small action items.
+
+DeeptiG: Could reuse the working group meeting slot since it's canceled a lot.
+
+AK: I like the general sound of that. A place where we’re writing down 
+
+LW: Let’s keep the website updated, maybe a news section of the site.
+
+BT: A lot of meetings are canceled. Maybe we should never cancel. Use that time to address the backlog. Canceling sends a bad signal to the community.
+
+AC: For community stuff, there are folks doing everything by themselves with zero budget. I love the idea of using something else with the time instead of canceling meetings. I box things on a monthly release schedule so all the things you prefer to discuss but not do are done at some point. I would love a monthly update from the community. It triggers the mind to tidy things up.
+
+RH: When getting up to speed read FAQ. There was a lot of community/tribal knowledge around things like GOTO. It’s hard to get the general idea of what’s going on. That would go well into a FAQ.
+
+DS: Thank you Deepti for organizing everything!
+
+### Closure


### PR DESCRIPTION
Thanks everyone for presenting at, and attending the meeting a couple of weeks ago. A few post meeting subgroup discussions are in progress, please follow up in the relevant subgroup meetings for follow up discussions. A quick summary:

- GC  Subgroup is whittling down the remaining issues
- SIMD subgroup is working through the feedback with additional polls for relaxed mode, deterministic lowerings
- Stacks subgroup is distilling the discussion into differences between the proposals

We may make a few minor changes to the meeting notes, but please submit PRs for edits especially if your views are not accurately represented in the notes, or you would like to be added to the attendee list. 