### PR TITLE
Mention new wasm-opt GC docs in meeting?

### DIFF
--- a/gc/2022/GC-12-13.md
+++ b/gc/2022/GC-12-13.md
@@ -27,6 +27,7 @@ Installation is required, see the calendar invite.
 1. Proposals and discussions
     1. Discussion: Types on the JS-Wasm boundary ([#279](https://github.com/WebAssembly/gc/issues/279))
     1. Discussion: Final types and call_indirect subtyping ([#329](https://github.com/WebAssembly/gc/issues/329), [#339](https://github.com/WebAssembly/gc/pull/339))
+    1. Quick announcement (1 minute): [New documentation page](https://github.com/WebAssembly/binaryen/wiki/GC-Optimization-Guidebook) for getting the most out of `wasm-opt` on Wasm GC content.
 1. Closure
 
 ## Meeting Notes


### PR DESCRIPTION
There is now a wiki page on using the Binaryen optimizer on wasm GC content:

https://github.com/WebAssembly/binaryen/wiki/GC-Optimization-Guidebook

It might be useful for people implementing toolchains to wasm GC, so I thought to mention it in the meeting. Could just be a 1-minute announcement. Or maybe there's a more suitable place?