### PR TITLE
Add an agenda item for discussing the `_initialize` convention.

### DIFF
--- a/main/2023/CG-04-11.md
+++ b/main/2023/CG-04-11.md
@@ -23,6 +23,12 @@ Installation is required, see the calendar invite.
     1. Introduction of attendees
 1. Find volunteers for note taking (acting chair to volunteer)
 1. Proposals and discussions
+   1. Add a `_initialize` convention in tool-conventions
+     - This would add a new tool-conventions document named
+       BasicModuleABI.md which would define the `_initialize` convention.
+     - See https://github.com/WebAssembly/tool-conventions/pull/203
+       for details.
+
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
Add an agenda item for discussing the proposed `_initialize` convention in tool-conventions.

     - This would add a new tool-conventions document named
       BasicModuleABI.md which would define the `_initialize` convention.

     - See https://github.com/WebAssembly/tool-conventions/pull/203
       for details.

I'm following the process described at the bottom of [this comment]. I'm open to alternative approaches to solving the problem.

[this comment]: https://github.com/WebAssembly/tool-conventions/pull/203#issue-1612325340