### PR TITLE
Fix typo: 'sumbit' -> 'submit'

### DIFF
--- a/wasi/2023/WASI-01-26.md
+++ b/wasi/2023/WASI-01-26.md
@@ -25,7 +25,7 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
     1. [WASI SQL Embedding](https://hackmd.io/Q93MXGLYTRSeGw7FVelURg) - Kyle Brown
 
@@ -63,7 +63,7 @@ The meeting will be on a zoom.us video conference.
 
 #### SQL embedding proposal
 
-**Kyle Brown**: Design doc. Outline of embedding wasm as user objects into a database. Several things that need to be solved. If embed component, have to identify user objects, and these overlap in their type. Could be single col value, could be series of col values. Need a way to disambig. Can emad in URL of different exports. UDF which takes in some num of col vals, as opposed to aggregate that takes in more than 1 row. 
+**Kyle Brown**: Design doc. Outline of embedding wasm as user objects into a database. Several things that need to be solved. If embed component, have to identify user objects, and these overlap in their type. Could be single col value, could be series of col values. Need a way to disambig. Can emad in URL of different exports. UDF which takes in some num of col vals, as opposed to aggregate that takes in more than 1 row.
 
 I believe URL no longer in wit, so need to figure that out. Need to identify different parts of type. For UD aggregate function, there are typically 4 funcs. Largely this can be done as an interface. Ways to generalize over these different kinds of function shapes. No structured annotations required.
 
@@ -71,7 +71,7 @@ Identifying user objects, identifying the parts of them. Last thing is SQL types
 
 Additionally, there’s the option to have some wrapper types, like new pattern in rust. The record type acts as a named alias that maps to SQL type. Much more control over how it gets into SQL context. Could install entire extension without out of band data.
 
-Might want variations of user object, e.g. reduce way. If we present different APIs, they’d be different interfaces. 
+Might want variations of user object, e.g. reduce way. If we present different APIs, they’d be different interfaces.
 
 Interested in moving forward as a proposal
 
@@ -89,7 +89,7 @@ Interested in moving forward as a proposal
 
 **Kyle Brown**: In that case, could bring in but then would be SQL error. If an init takes in a type, then other funcs will need to take that type. That would largely be an external validation.
 
-Floated an idea of abstract interface. This interface needs a state type but doesn’t define what it is. 
+Floated an idea of abstract interface. This interface needs a state type but doesn’t define what it is.
 
 **Luke Wagner**: Thinking about it, if you said typestate = anyval, and use state everywhere, that pins down that you’re using the same type everywhere. That’s coming up in wit.
 

--- a/wasi/2023/WASI-02-09.md
+++ b/wasi/2023/WASI-02-09.md
@@ -25,7 +25,7 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
     1. A possible roadmap for WASI Preview1, Preview2, Preview3, and WASI 1.0 - Dan Gohman (slides: [pdf](presentations/2023-02-09-gohman-wasi-roadmap.pdf))
       - A proposed framework for Preview3 and WASI 1.0: https://github.com/WebAssembly/WASI/issues/515
@@ -83,29 +83,29 @@ At each point, can incorp real world feedback. May need to make breaking changes
 
 Questions?
 
-**Andrew Brown:** Which proposals do you see as being a part of Preview 2, Preview 3, and 1.0. Do you see just the 5 original, or can several other of the 20 be included. 
+**Andrew Brown:** Which proposals do you see as being a part of Preview 2, Preview 3, and 1.0. Do you see just the 5 original, or can several other of the 20 be included.
 
 **Dan Gohman:** At each stage, we’ll say everything that is ready can join the party. Just about timing. Timeline defined by CM and wit tooling readiness. Original fs, clocks, random set. Hoping those will be ready, Hoping that other proposals could advance and be ready.
 
-**Andrew Brown:** So you know what’s required what’s needed for Preview 2, but other authors don’t necessarily have that insight. 
+**Andrew Brown:** So you know what’s required what’s needed for Preview 2, but other authors don’t necessarily have that insight.
 
 **Dan Gohman:** Good question. Next step for me to write up docs. Then we can put together a framework, and as part of that explain that you need to write in the wit format. Could add other criteria, but the big criteria is wit. For Preview 3, if async is relevant, you make the changes, but otherwise no changes. For WASI 1.0, would need to go through CG.
 
 **Bailey Hayes:** Thanks for putting this together. I’d like to see—we want WASI to be modular. Some don’t make sense for all runtimes. I think one thing that will help is showing that now with the modular set of interfaces what it looks like when one isn’t supported.
 
-**Dan Gohman:** Great idea. I think the world concept is the first building block to getting there. That will define sets of APIs. The world is the nexus between developers and platforms. WASI subgroup will define some number of standardized worlds. Other worlds people have talked about, e.g. embedded systems. You can also build worlds on top of worlds with your custom APIs. 
+**Dan Gohman:** Great idea. I think the world concept is the first building block to getting there. That will define sets of APIs. The world is the nexus between developers and platforms. WASI subgroup will define some number of standardized worlds. Other worlds people have talked about, e.g. embedded systems. You can also build worlds on top of worlds with your custom APIs.
 
-CW: Exactly what Bailey said, thanks for this hard work. From an external perspective, WASI user C developer point of view. What’s the impact. Preview 1, not much. Preview 2, would need C interfaces going towards wit. For P2, have a situation where I could create a component with P2, but it will only execute on what supports that. P3 is going to be the same. 
+CW: Exactly what Bailey said, thanks for this hard work. From an external perspective, WASI user C developer point of view. What’s the impact. Preview 1, not much. Preview 2, would need C interfaces going towards wit. For P2, have a situation where I could create a component with P2, but it will only execute on what supports that. P3 is going to be the same.
 
 **Dan Gohman:** Yes, there will be a transition period. One thing that is happening is a preview 1 -> 2 adapter toolchain. Can take Preview 1 impl forward migration
 
-CW: Then engine impl will just have to play catch up. We may be able to help with C++ runtimes. If you could keep us in mind. 
+CW: Then engine impl will just have to play catch up. We may be able to help with C++ runtimes. If you could keep us in mind.
 
 **Dan Gohman:** WASI sg meeting is a great place to keep up with things. Also follow me on social media, Mastodon
 
-**Piotr Sikora:** Especially like that you aren’t abandoning Preview 1 users. Question, what timeline? Especially if we want feedback, sounds like multi-year process before WASI 1.0. 
+**Piotr Sikora:** Especially like that you aren’t abandoning Preview 1 users. Question, what timeline? Especially if we want feedback, sounds like multi-year process before WASI 1.0.
 
-**Dan Gohman:** That’s right, don’t expect to be as long as Preview 1. 
+**Dan Gohman:** That’s right, don’t expect to be as long as Preview 1.
 
 **Piotr Sikora:** Are we expecting at least 1 year between?
 
@@ -133,7 +133,7 @@ CW: Then engine impl will just have to play catch up. We may be able to help wit
 
 **Dan Gohman:** Current thinking is we continue with current scheme will define its own thing. All the command APIs expect to support Windows, MacOS, Linux. Other APIs can define what they do. WASI as a whole with the framework we’re talking about, lots won’t be portable. We don’t want to preclude those to not being part of WASI. Maybe the world mechanism is a way to impose more portability rules. Feels to me we can do it world by world.
 
-**Deepti Gandaluri:** Think that answers my question. Mentions that at each level would be taking implementation feedback. Maybe the worlds answer this to an extent, but what impl feedback is what you block on or move to a further preview. 
+**Deepti Gandaluri:** Think that answers my question. Mentions that at each level would be taking implementation feedback. Maybe the worlds answer this to an extent, but what impl feedback is what you block on or move to a further preview.
 
 **Dan Gohman:** This is more open ended because there’s more diversity between engine impl styles. Same thing basically applies though. If someone raises a problem for core, like SIMD, and one person says that it doesn’t work on x86, that applies to most engines. We can use the same process of figuring out how valid that concern is. In the core wasm spec process, we just work through that and champion makes judgement call. Those are the decision making process that we follow. We can say we trust the champion. If someone has some super exotic changes, then the champion can define the scope. E.g. someone trying to impl a fs on a system that doesn’t have an fs, the champion can scope to only platforms that have fs and figure out the others with a different proposal.
 
@@ -141,7 +141,7 @@ Currently champions can make decisions, CG can vote.
 
 **Deepti Gandaluri:** We do have a minimal subset of two web vms
 
-**Dan Gohman:** We do have an analog for that, where the SG votes on each proposals 
+**Dan Gohman:** We do have an analog for that, where the SG votes on each proposals
 
 **Deepti Gandaluri:** I see the parallel to that, but was harder for me to reason about
 
@@ -159,13 +159,13 @@ Currently champions can make decisions, CG can vote.
 
 ### Reorganizing the Preview 1 files
 
-**Dan Gohman:** Just calling attention to the PR. 
+**Dan Gohman:** Just calling attention to the PR.
 
 ### Should Preview1 fd_readdir filter out . and ..
 
-**Dan Gohman:** POSIX historically included. A lot of languages have filtered those out because users don’t care about those. Idea is that we could also filter these out and then re-add them. Then there’s a question of what Preview 1 should do. Could just continue to do the POSIX conforming. Curious about sg 
+**Dan Gohman:** POSIX historically included. A lot of languages have filtered those out because users don’t care about those. Idea is that we could also filter these out and then re-add them. Then there’s a question of what Preview 1 should do. Could just continue to do the POSIX conforming. Curious about sg
 
-**Pat Hickey:** Because there are existing P1 programs, we shouldn’t make changes like this. 
+**Pat Hickey:** Because there are existing P1 programs, we shouldn’t make changes like this.
 
 **Dan Gohman:** I’m seeing sam as a thumbsup up there. More broadly, I think any changes to P1 should increase compat and we should try not to introduce non-determinism. That sound right? Looks like agreement
 
@@ -217,29 +217,29 @@ At each point, can incorp real world feedback. May need to make breaking changes
 
 Questions?
 
-**Andrew Brown:** Which proposals do you see as being a part of Preview 2, Preview 3, and 1.0. Do you see just the 5 original, or can several other of the 20 be included. 
+**Andrew Brown:** Which proposals do you see as being a part of Preview 2, Preview 3, and 1.0. Do you see just the 5 original, or can several other of the 20 be included.
 
 **Dan Gohman:** At each stage, we’ll say everything that is ready can join the party. Just about timing. Timeline defined by CM and wit tooling readiness. Original fs, clocks, random set. Hoping those will be ready, Hoping that other proposals could advance and be ready.
 
-**Andrew Brown:** So you know what’s required what’s needed for Preview 2, but other authors don’t necessarily have that insight. 
+**Andrew Brown:** So you know what’s required what’s needed for Preview 2, but other authors don’t necessarily have that insight.
 
 **Dan Gohman:** Good question. Next step for me to write up docs. Then we can put together a framework, and as part of that explain that you need to write in the wit format. Could add other criteria, but the big criteria is wit. For Preview 3, if async is relevant, you make the changes, but otherwise no changes. For WASI 1.0, would need to go through CG.
 
 **Bailey Hayes:** Thanks for putting this together. I’d like to see—we want WASI to be modular. Some don’t make sense for all runtimes. I think one thing that will help is showing that now with the modular set of interfaces what it looks like when one isn’t supported.
 
-**Dan Gohman:** Great idea. I think the world concept is the first building block to getting there. That will define sets of APIs. The world is the nexus between developers and platforms. WASI subgroup will define some number of standardized worlds. Other worlds people have talked about, e.g. embedded systems. You can also build worlds on top of worlds with your custom APIs. 
+**Dan Gohman:** Great idea. I think the world concept is the first building block to getting there. That will define sets of APIs. The world is the nexus between developers and platforms. WASI subgroup will define some number of standardized worlds. Other worlds people have talked about, e.g. embedded systems. You can also build worlds on top of worlds with your custom APIs.
 
-CW: Exactly what Bailey said, thanks for this hard work. From an external perspective, WASI user C developer point of view. What’s the impact. Preview 1, not much. Preview 2, would need C interfaces going towards wit. For P2, have a situation where I could create a component with P2, but it will only execute on what supports that. P3 is going to be the same. 
+CW: Exactly what Bailey said, thanks for this hard work. From an external perspective, WASI user C developer point of view. What’s the impact. Preview 1, not much. Preview 2, would need C interfaces going towards wit. For P2, have a situation where I could create a component with P2, but it will only execute on what supports that. P3 is going to be the same.
 
 **Dan Gohman:** Yes, there will be a transition period. One thing that is happening is a preview 1 -> 2 adapter toolchain. Can take Preview 1 impl forward migration
 
-CW: Then engine impl will just have to play catch up. We may be able to help with C++ runtimes. If you could keep us in mind. 
+CW: Then engine impl will just have to play catch up. We may be able to help with C++ runtimes. If you could keep us in mind.
 
 **Dan Gohman:** WASI sg meeting is a great place to keep up with things. Also follow me on social media, Mastodon
 
-**Piotr Sikora:** Especially like that you aren’t abandoning Preview 1 users. Question, what timeline? Especially if we want feedback, sounds like multi-year process before WASI 1.0. 
+**Piotr Sikora:** Especially like that you aren’t abandoning Preview 1 users. Question, what timeline? Especially if we want feedback, sounds like multi-year process before WASI 1.0.
 
-**Dan Gohman:** That’s right, don’t expect to be as long as Preview 1. 
+**Dan Gohman:** That’s right, don’t expect to be as long as Preview 1.
 
 **Piotr Sikora:** Are we expecting at least 1 year between?
 
@@ -267,7 +267,7 @@ CW: Then engine impl will just have to play catch up. We may be able to help wit
 
 **Dan Gohman:** Current thinking is we continue with current scheme will define its own thing. All the command APIs expect to support Windows, MacOS, Linux. Other APIs can define what they do. WASI as a whole with the framework we’re talking about, lots won’t be portable. We don’t want to preclude those to not being part of WASI. Maybe the world mechanism is a way to impose more portability rules. Feels to me we can do it world by world.
 
-**Deepti Gandaluri:** Think that answers my question. Mentions that at each level would be taking implementation feedback. Maybe the worlds answer this to an extent, but what impl feedback is what you block on or move to a further preview. 
+**Deepti Gandaluri:** Think that answers my question. Mentions that at each level would be taking implementation feedback. Maybe the worlds answer this to an extent, but what impl feedback is what you block on or move to a further preview.
 
 **Dan Gohman:** This is more open ended because there’s more diversity between engine impl styles. Same thing basically applies though. If someone raises a problem for core, like SIMD, and one person says that it doesn’t work on x86, that applies to most engines. We can use the same process of figuring out how valid that concern is. In the core wasm spec process, we just work through that and champion makes judgement call. Those are the decision making process that we follow. We can say we trust the champion. If someone has some super exotic changes, then the champion can define the scope. E.g. someone trying to impl a fs on a system that doesn’t have an fs, the champion can scope to only platforms that have fs and figure out the others with a different proposal.
 
@@ -275,7 +275,7 @@ Currently champions can make decisions, CG can vote.
 
 **Deepti Gandaluri:** We do have a minimal subset of two web vms
 
-**Dan Gohman:** We do have an analog for that, where the SG votes on each proposals 
+**Dan Gohman:** We do have an analog for that, where the SG votes on each proposals
 
 **Deepti Gandaluri:** I see the parallel to that, but was harder for me to reason about
 
@@ -293,12 +293,12 @@ Currently champions can make decisions, CG can vote.
 
 ### Reorganizing the Preview 1 files
 
-**Dan Gohman:** Just calling attention to the PR. 
+**Dan Gohman:** Just calling attention to the PR.
 
 ### Should Preview1 fd_readdir filter out . and ..
 
-**Dan Gohman:** POSIX historically included. A lot of languages have filtered those out because users don’t care about those. Idea is that we could also filter these out and then re-add them. Then there’s a question of what Preview 1 should do. Could just continue to do the POSIX conforming. Curious about sg 
+**Dan Gohman:** POSIX historically included. A lot of languages have filtered those out because users don’t care about those. Idea is that we could also filter these out and then re-add them. Then there’s a question of what Preview 1 should do. Could just continue to do the POSIX conforming. Curious about sg
 
-**Pat Hickey:** Because there are existing P1 programs, we shouldn’t make changes like this. 
+**Pat Hickey:** Because there are existing P1 programs, we shouldn’t make changes like this.
 
 **Dan Gohman:** I’m seeing sam as a thumbsup up there. More broadly, I think any changes to P1 should increase compat and we should try not to introduce non-determinism. That sound right? Looks like agreement

--- a/wasi/2023/WASI-02-23.md
+++ b/wasi/2023/WASI-02-23.md
@@ -25,7 +25,7 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
     1. New proposal: wasi-cli: A command-line interface world
         1. https://github.com/WebAssembly/WASI/issues/509
@@ -59,9 +59,9 @@ The meeting will be on a zoom.us video conference.
 
 ### wasi-cli proposal to Phase 1
 
-**Dan Gohman**: This is a proposal to vote for Phase 1 for WASI CLI world. Moving to a format where we have a wit file, and then dependencies are vendored in. The deps dir would serve purpose of collecting everything in the cli world. 
+**Dan Gohman**: This is a proposal to vote for Phase 1 for WASI CLI world. Moving to a format where we have a wit file, and then dependencies are vendored in. The deps dir would serve purpose of collecting everything in the cli world.
 
-There’s a sketch in the issue linked in the agenda of what this world will look like. Some things will change, but that’s appropriate for phase 1. 
+There’s a sketch in the issue linked in the agenda of what this world will look like. Some things will change, but that’s appropriate for phase 1.
 
 **Lin Clark**: Vote. Any objection? No. Congrats on another proposal!
 
@@ -71,7 +71,7 @@ There’s a sketch in the issue linked in the agenda of what this world will loo
 
 **Lin Clark**: Vote. Any objections? No. Congrats on your new proposal!
 
-**Carlo Piovesan**: Question. One very minor bit of feedback: I’m not sure whether layering a bit more would allow to move faster. Seems that the scope is very wide. 
+**Carlo Piovesan**: Question. One very minor bit of feedback: I’m not sure whether layering a bit more would allow to move faster. Seems that the scope is very wide.
 
 **Kyle Brown**: Yes, scope of it is large. A number of different types we’re interested in. Might phase it within the proposal. May do more piece by picee. Original proposal has a sketch for all of it to demonstrate the scope.
 

--- a/wasi/2023/WASI-03-09.md
+++ b/wasi/2023/WASI-03-09.md
@@ -25,7 +25,7 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
     1. [Proposal: Union of Worlds](https://github.com/WebAssembly/component-model/issues/169) — [slides](https://docs.google.com/presentation/d/1HD05eyUya-fNYDHG1mfVdQGKPjL_8Sk4rS0TYJHe6aI/edit#slide=id.p) by Mossaka
         1. initial feedback
@@ -66,13 +66,13 @@ The meeting will be on a zoom.us video conference.
 
 ### Proposal: Union of Worlds
 
-**Jiaxiao (Joe) Zhou**: Motivation that we want to rapidly form bigger worlds by combining smaller worlds. Will introduce new syntax. Will sketch out what that means for use statements. Simplest example: imagine we have two worlds, A and B. A is importing a, b, export c. B imports foo, bar, exports baz. We can union with the include syntax. 
+**Jiaxiao (Joe) Zhou**: Motivation that we want to rapidly form bigger worlds by combining smaller worlds. Will introduce new syntax. Will sketch out what that means for use statements. Simplest example: imagine we have two worlds, A and B. A is importing a, b, export c. B imports foo, bar, exports baz. We can union with the include syntax.
 
-Include syntax should be able to specify a world path. The world path will be very similar to the use path. That means the world path will have qualifications like self, etc. Example of including external package. 
+Include syntax should be able to specify a world path. The world path will be very similar to the use path. That means the world path will have qualifications like self, etc. Example of including external package.
 
-More challenging example: name conflicts. Suppose we have two world, 1 and 2. Both include A and B. Besides basic include, have with syntax. 
+More challenging example: name conflicts. Suppose we have two world, 1 and 2. Both include A and B. Besides basic include, have with syntax.
 
-Last example, deduplication. A bit more fuzzy on this one. Want to solve transient dependency problem. Two worlds are including same. We can just rename because they are structurally the same. 
+Last example, deduplication. A bit more fuzzy on this one. Want to solve transient dependency problem. Two worlds are including same. We can just rename because they are structurally the same.
 
 Next thing is a little more subtle. Union subtyping. We define component subtyping as in the CM. What does this mean for union for worlds. This means that any component that can run in A or B is a subtype of C. This means that any imports in A or B, must be present in C. But goes reverse for exports, and exports of C must be present in A or B. But in example A, that doesn’t apply. This creates a subtyping issue we have to solve. There are two solutions. Short term, have to ask host binding to implicitly interpret exports as optional. This is just a short term solution because not explicitly expressed in wit. Longer term, need to make optional imports and exports.
 
@@ -88,15 +88,15 @@ Final question: can wit package store not only interfaces but also worlds?
 
 **Jiaxiao (Joe) Zhou**: : That was a mistake in the slides.
 
-**Pat Hickey**: I wanted to call something out that I’m nervous will be a problem Two worlds each import two different logging. People have to agree that they’ll import under same name. If you don’t do that, you can’t compass. So it’s like you better always name wasi-logging console, or you might be stuck later. 
+**Pat Hickey**: I wanted to call something out that I’m nervous will be a problem Two worlds each import two different logging. People have to agree that they’ll import under same name. If you don’t do that, you can’t compass. So it’s like you better always name wasi-logging console, or you might be stuck later.
 
-**Jiaxiao (Joe) Zhou**: If wasi-logging is being imported twice in two worlds. Does it make sense to run de-dupe first so we don’t have to handle the name conflict? 
+**Jiaxiao (Joe) Zhou**: If wasi-logging is being imported twice in two worlds. Does it make sense to run de-dupe first so we don’t have to handle the name conflict?
 
 **Pat Hickey**: Does this mean that we only dedupe when name is same and not URL.
 
 **Jiaxiao (Joe) Zhou**: That’s the kind of unclear part that I mentioned. Are we going to have structural or nominal typing.
 
-**Pat Hickey**: I think I’m advocating for structural typing. 
+**Pat Hickey**: I think I’m advocating for structural typing.
 
 **Jiaxiao (Joe) Zhou**: I agree with structure matching. Actually more challenging because at moment wit parser doesn’t do any structure matching.
 
@@ -104,21 +104,21 @@ Final question: can wit package store not only interfaces but also worlds?
 
 ### New proposal: gpio/i2c/SPI API
 
-**Emiel Van Severen**: Proposal regarding embedded world. Until now, focus has mostly been on runtimes that work in very constrained envs. Also things like wasi-messaging, which will probably be used a lot since it introduces a lot of protocols. Until now, no real interface for hardware. Gpio pins, etc. I want to introduce these hardwares. Can take example of embedded Rust. SVD files created by board creators. These files can be parsed by a cli tool, and creates a lowlevel crate that allows you to write into specific registers. Devs don’t usually want that, so you often have higher level API called HALs. Two people might use different names, though. Idea for embedded HALs is to provide traits to offer compatibility. If you implement the traits, then can use across these different boards. I think WASI could be the mapping layer. 
+**Emiel Van Severen**: Proposal regarding embedded world. Until now, focus has mostly been on runtimes that work in very constrained envs. Also things like wasi-messaging, which will probably be used a lot since it introduces a lot of protocols. Until now, no real interface for hardware. Gpio pins, etc. I want to introduce these hardwares. Can take example of embedded Rust. SVD files created by board creators. These files can be parsed by a cli tool, and creates a lowlevel crate that allows you to write into specific registers. Devs don’t usually want that, so you often have higher level API called HALs. Two people might use different names, though. Idea for embedded HALs is to provide traits to offer compatibility. If you implement the traits, then can use across these different boards. I think WASI could be the mapping layer.
 
 I think we should also maybe think about the high level APIs like LED. If we think about WASM, we think about completely agnostic. In this case, how do we fix? Maybe manifests like Android? LEDs could be desbribed as whether they are optional or not. This is where it’s a bit fuzzy for me. You probably have HALs that have to interface with memory. But since each has its own memory. How can I interact with the memory. If I use what’s in the module, it should be immutable. It’s a bit fuzzy for me.
 
-Want to finish with is WebAssembly the solution. Could be a lot of work but I think the embedded world is very fragmented and this could help. Eventually people want to program in higher level languages, and I think wasm will enable this. 
+Want to finish with is WebAssembly the solution. Could be a lot of work but I think the embedded world is very fragmented and this could help. Eventually people want to program in higher level languages, and I think wasm will enable this.
 
 **Bailey Hayes**: This is great and I love it. I’ve also been thinking about this problem. I’ve been trying to make this work with WAMR and vxworks. Approach I’m interested in is WebIDL and a way to interop between that and wit. There are a few different APIs I think you’d be into like sensors, others. Would love to collaborate!
 
 **Emiel Van Severen**: would love that.
 
-**Kyle Brown**: On the subject before about different devices having different quantities of hardware, like LEDs. That seems like a good use case for wit templates. That then becomes part of the component. The component is then self-describing. 
+**Kyle Brown**: On the subject before about different devices having different quantities of hardware, like LEDs. That seems like a good use case for wit templates. That then becomes part of the component. The component is then self-describing.
 
 **Emiel Van Severen**: Haven’t looked at wit templates.
 
-**Kyle Brown**: Have been several presentations. 
+**Kyle Brown**: Have been several presentations.
 
 **Bailey Hayes**: https://github.com/WebAssembly/component-model/issues/172
 
@@ -126,6 +126,6 @@ Want to finish with is WebAssembly the solution. Could be a lot of work but I th
 
 **Emiel Van Severen**: could be an option
 
-**Chris Woods**: We’ve been doing a lot on this work too. We did some perf analysis. Like Bailey, would love to collaborate. Regarding the memory sharing. Rust version you showed is something you see a lot. There’s a nuance in understanding what you’re exposing. That shifts the requirement for response time to something outside wasm. The business logic is in wasm but the underlying real time control that would be done outside the wasm world. You see that with filesystems, server for network interface. With that, you don’t need to share memory. That would map quite well with the component model. But the smaller the device, the harder it is to make the case. 
+**Chris Woods**: We’ve been doing a lot on this work too. We did some perf analysis. Like Bailey, would love to collaborate. Regarding the memory sharing. Rust version you showed is something you see a lot. There’s a nuance in understanding what you’re exposing. That shifts the requirement for response time to something outside wasm. The business logic is in wasm but the underlying real time control that would be done outside the wasm world. You see that with filesystems, server for network interface. With that, you don’t need to share memory. That would map quite well with the component model. But the smaller the device, the harder it is to make the case.
 
 **Lin Clark**: Ok, poll for Phase 1. Any objections? No? Congrats on new proposal! Email me to get set up.

--- a/wasi/2023/WASI-03-23.md
+++ b/wasi/2023/WASI-03-23.md
@@ -30,7 +30,7 @@ The meeting will be on a zoom.us video conference.
     1. Discuss Status of WASI-Crypto, whether it still actively being championed, etc.
     1. Propose `wasi-pattern-match`; request stage 0 consensus vote -- 20 minutes (@jianjunz,
        [slides](presentations/2023-03-23-wasi-pattern-match.pdf))
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 
 ## Notes
 ### Attendees
@@ -54,7 +54,7 @@ The meeting will be on a zoom.us video conference.
 - Stephen Doyle
 - Dan Chairlone
 - David Justice
-- Steve Schoettler 
+- Steve Schoettler
 
 ### Wasi-crypto
 
@@ -65,7 +65,7 @@ The meeting will be on a zoom.us video conference.
 
 **Frank Denis:**  there are two implementations today: wasmedge is the most up-to-date, and there is one in wasmtime that you need to apply a PR on top of to make it up-to-date.
 
-**Frank Denis:**  the todo list for the project: build an ecosystem on top of this spec. Libraries exist today for AssemblyScript, and two in Rust (wasi-crypto-guest, crypto-wasi). These are just bindings over the interface, not what end users should be expected to use. Real world users want transparent support in a JWT library, or in the Zig standard library. 
+**Frank Denis:**  the todo list for the project: build an ecosystem on top of this spec. Libraries exist today for AssemblyScript, and two in Rust (wasi-crypto-guest, crypto-wasi). These are just bindings over the interface, not what end users should be expected to use. Real world users want transparent support in a JWT library, or in the Zig standard library.
 
 **Frank Denis:**  We need a test suite, at very least test vectors to guarantee interoperability. A reference implementation would be nice, the wasmedge and wasmtime implementations are not very simple or readable in order to be fast.
 

--- a/wasi/2023/WASI-04-20.md
+++ b/wasi/2023/WASI-04-20.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-05-04.md
+++ b/wasi/2023/WASI-05-04.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-05-18.md
+++ b/wasi/2023/WASI-05-18.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-06-01.md
+++ b/wasi/2023/WASI-06-01.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-06-15.md
+++ b/wasi/2023/WASI-06-15.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-06-29.md
+++ b/wasi/2023/WASI-06-29.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-07-13.md
+++ b/wasi/2023/WASI-07-13.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-07-27.md
+++ b/wasi/2023/WASI-07-27.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-08-10.md
+++ b/wasi/2023/WASI-08-10.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-08-24.md
+++ b/wasi/2023/WASI-08-24.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-09-07.md
+++ b/wasi/2023/WASI-09-07.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-09-21.md
+++ b/wasi/2023/WASI-09-21.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-10-05.md
+++ b/wasi/2023/WASI-10-05.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-10-19.md
+++ b/wasi/2023/WASI-10-19.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-11-02.md
+++ b/wasi/2023/WASI-11-02.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-11-16.md
+++ b/wasi/2023/WASI-11-16.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-11-30.md
+++ b/wasi/2023/WASI-11-30.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2023/WASI-12-14.md
+++ b/wasi/2023/WASI-12-14.md
@@ -25,6 +25,6 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Sumbit a PR to add your announcement here_
+    1. _Submit a PR to add your announcement here_


### PR DESCRIPTION
I notice this every time I edit one of the meeting pages so I thought I would replace all of the typos in WASI's 2023 meeting pages.