### PR TITLE
WASI-07-27: Dan will also present on rebasing the phase process

### DIFF
--- a/wasi/2023/WASI-07-27.md
+++ b/wasi/2023/WASI-07-27.md
@@ -27,5 +27,7 @@ The meeting will be on a zoom.us video conference.
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. Dan Gohman: Preview 2 definition plan
+    1. Dan Gohman: Rebase the Phase Process description on the CG's current
+       process (https://github.com/WebAssembly/WASI/pull/549)
+    1. Dan Gohman: Preview 2 definition plan (https://github.com/WebAssembly/WASI/pull/550)
     1. Marcin Kolny: The future of WASI threads proposal (https://github.com/WebAssembly/wasi-threads/issues/48)


### PR DESCRIPTION
We would typically add this agenda after the two existing ones, but it is tightly coupled to Dan's preview 2 definition plan item, so we need to do it first.