### PR TITLE
Add EH update to 2023-09-12 CG meeting

### DIFF
--- a/main/2023/CG-09-12.md
+++ b/main/2023/CG-09-12.md
@@ -23,6 +23,9 @@ Installation is required, see the calendar invite.
     1. Introduction of attendees
 1. Find volunteers for note taking (acting chair to volunteer)
 1. Proposals and discussions
+    1. Exception handling updates
+        1. Reminder: Upcoming vote on the exnref proposal in the Oct CG meeting
+        1. Adding Ben Titzer as a co-champion to the proposal
     1. Vote to advance function references and GC proposals to phase 4 [30 min]
     1. Teaser: a DSL for authoring the spec [Andreas Rossberg, 30 min]
 1. Closure

--- a/main/2023/CG-09-12.md
+++ b/main/2023/CG-09-12.md
@@ -23,7 +23,7 @@ Installation is required, see the calendar invite.
     1. Introduction of attendees
 1. Find volunteers for note taking (acting chair to volunteer)
 1. Proposals and discussions
-    1. Exception handling updates
+    1. Exception handling announcements
         1. Reminder: Upcoming vote on the exnref proposal in the Oct CG meeting
         1. Adding Ben Titzer as a co-champion to the proposal
     1. Vote to advance function references and GC proposals to phase 4 [30 min]

--- a/main/2023/CG-09-26.md
+++ b/main/2023/CG-09-26.md
@@ -22,10 +22,9 @@ Installation is required, see the calendar invite.
     1. Opening of the meeting
     1. Introduction of attendees
 1. Find volunteers for note taking (acting chair to volunteer)
-1. Proposals and discussions [15 mins]
-    1. Exception handling updates
-        1. Reminder: Upcoming vote on the exnref proposal in the Oct CG meeting
-        1. Adding Ben Titzer as a co-champion to the proposal
+1. Proposals and discussions
+    1. Exception handling: Potential discussions about the upcoming vote
+       [15 min]
     1. Profiles discussion (rescheduled from 06/20/2023) [30 mins]
 1. Closure
 

--- a/main/2023/CG-09-26.md
+++ b/main/2023/CG-09-26.md
@@ -22,7 +22,10 @@ Installation is required, see the calendar invite.
     1. Opening of the meeting
     1. Introduction of attendees
 1. Find volunteers for note taking (acting chair to volunteer)
-1. Proposals and discussions
+1. Proposals and discussions [15 mins]
+    1. Exception handling updates
+        1. Reminder: Upcoming vote on the exnref proposal in the Oct CG meeting
+        1. Adding Ben Titzer as a co-champion to the proposal
     1. Profiles discussion (rescheduled from 06/20/2023) [30 mins]
 1. Closure
 


### PR DESCRIPTION
Given that 9/12 is fully scheduled already, we'd like to do a brief anouncement of the co-championship and reminder of the upcoming vote on 9/12, which will only take a few minutes. If this sparks more discussions, we'd like to address them in 9/26 slot. The 9/26 slot, if it happens, should be the first item because @titzer can attend only the first half of the meeting. I'll cancel the 9/26 slot later if that doesn't seem to be necessary by then.