### PR TITLE
Add an agenda item to 2023/WASI-10-05.md: advance wasi-cli to phase 2

### DIFF
--- a/wasi/2023/WASI-10-05.md
+++ b/wasi/2023/WASI-10-05.md
@@ -27,4 +27,6 @@ The meeting will be on a zoom.us video conference.
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Submit a PR to add your announcement here_
+    1. Vote: Advance [wasi-cli](https://github.com/WebAssembly/wasi-cli) to phase 2
+       - All upstream proposals are at phase 2.
+       - Portability criteria are the same as the other WASI proposals.


### PR DESCRIPTION
All upstream proposals of wasi-cli are at phase 2, and wasi-cli has the same portability criteria as the upstream proposals.