### PR TITLE
Add a schedule for the October CG meeting

### DIFF
--- a/main/2023/CG-10.md
+++ b/main/2023/CG-10.md
@@ -51,48 +51,54 @@ After entering the inner yard, turn right in the yard and go to the reception wh
 #### Meals
 There will likely be some catering provided by Google. Details are to be defined and will be posted here.
 
-### Proposed agenda items (to be scheduled)
+### Schedule
 
-Please add any scheduling constraints here, especially if you're not able to travel, but would like to contribute to one of the agenda items. If you are adding a scheduling constraint, add the agenda item you are interested in attending, and timeslots that would work. Adding a constraint doesn't guarantee that we will be able to accommodate it, but we will attempt to make sure interested folks can attend and contribute. 
-
-- ...
+**Wednesday, 11th October**
+- Multi-Memory Phase 4 Vote
+  - 15 mins (Andreas Rossberg, Ashley Nelson)
+- Extended Name Section: Update and discussion on [name declarations](https://github.com/WebAssembly/annotations/issues/21)
+  - 15 mins (Ashley Nelson)
+- Profiles: Introducing new profiles, artifacts, and procedural discussion
+  - 60 mins (Andreas Rossberg)
+- Relaxed SIMD: Phase 4 vote
+  - 10 mins (Deepti Gandluri)
+- Type Reflection for WebAssembly JavaScript API: Update, tentative poll for Phase 4
+  - 30 mins (Ilya Rezvov)
+- Exception handling: Vote on [the proposed spec for reintroducing exnref](https://github.com/WebAssembly/exception-handling/issues/281)
+  - 30 mins (Heejin Ahn, Ben Titzer) 
+- Initial work on a DSL for the specification document
+  - 40 mins (Andreas Rossberg, Sukyoung Ryu, Conrad Watt)
+  - Prefer Wednesday, October 11th
 - Update on [threads proposal](https://github.com/WebAssembly/threads) (with phase 4 vote?)
   - 30 mins (Conrad Watt)
   - Any day after 3pm Munich time
 - Post-MVP threads discussion
   - 60 mins (Andrew Brown, Conrad Watt)
   - Any day after 3pm Munich time
-- Initial work on a DSL for the specification document
-  - 40 mins (Andreas Rossberg, Sukyoung Ryu, Conrad Watt)
-  - Prefer Wednesday, October 11th
-- Post-MVP GC discussion
-  - 45-60 mins (Andreas Rossberg)
-- Multi-Memory Phase 4 Vote
-  - 15 mins (Andreas Rossberg, Ashley Nelson)
+ 
+**Thursday, 12th October**
+- Component Model / WASI status update and next steps (Preview 2)
+  - 30 mins (Luke Wagner)
 - Wasm for Embedded Systems
   - 40 mins (Chris Woods)
   - To end before 12pm Munich time, either day
-- Exception handling: Vote on [the proposed spec for reintroducing exnref](https://github.com/WebAssembly/exception-handling/issues/281)
-  - 30 mins (Heejin Ahn, Ben Titzer)
-- Implementation report of memory.discard in SpiderMonkey
-  - 30 mins (Ryan Hunt)
+- Memory control:
+  - Proposal update 30 mins (Deepti Gandluri)
+  - Implementation report of memory.discard in SpiderMonkey 30 mins (Ryan Hunt)
 - Spritely's use of GC as a target for Scheme compilation
   - 45 mins (Andy Wingo)
 - Wasm_of_ocaml: compiling OCaml bytecode to WasmGC
   - 45 mins (Jérôme Vouillon)
-  - Prefer Thursday, October 12th
-- Component Model / WASI status update and next steps (Preview 2)
-  - 30 mins (Luke Wagner)
-- Profiles: Introducing new profiles, artifacts, and procedural discussion
+  - Prefer Thursday, October 12th 
+- Post-MVP GC discussion
   - 60 mins (Andreas Rossberg)
-- Relaxed SIMD: Phase 4 vote
-  - 15 mins (Deepti Gandluri)
-- Extended Name Section: Update and discussion on [name declarations](https://github.com/WebAssembly/annotations/issues/21)
-  - 15 mins (Ashley Nelson)
-- Memory control: Proposal update
-  - 30 mins (Deepti Gandluri)
-- Profile Guided Optimization hints: Pre-proposal discussion
-  - 30 mins (Emanuel Ziegler)
+  - Schedule in the afternoon, US overlap prefered  
+
+### Proposed agenda items (to be scheduled if time permits)
+
+Use this space to add any agenda items that need to be scheduled, and scheduling constraints here, especially if you're not able to travel, but would like to contribute to one of the agenda items. If you are adding a scheduling constraint, add the agenda item you are interested in attending, and timeslots that would work. Adding a constraint doesn't guarantee that we will be able to accommodate it, but we will attempt to make sure interested folks can attend and contribute. 
+
+- ...
 
 ## Meeting notes
 To be added after the meeting.

--- a/main/2023/CG-10.md
+++ b/main/2023/CG-10.md
@@ -83,13 +83,15 @@ There will likely be some catering provided by Google. Details are to be defined
   - 40 mins (Chris Woods)
   - To end before 12pm Munich time, either day
 - Memory control:
-  - Proposal update 30 mins (Deepti Gandluri)
+  - Proposal update 45 mins (Deepti Gandluri, Ryan Hunt)
   - Implementation report of memory.discard in SpiderMonkey 30 mins (Ryan Hunt)
 - Spritely's use of GC as a target for Scheme compilation
   - 45 mins (Andy Wingo)
 - Wasm_of_ocaml: compiling OCaml bytecode to WasmGC
   - 45 mins (Jérôme Vouillon)
-  - Prefer Thursday, October 12th 
+  - Prefer Thursday, October 12th
+- JS string builtins proposal update
+  - 30 minutes (Ryan Hunt)
 - Post-MVP GC discussion
   - 60 mins (Andreas Rossberg)
   - Schedule in the afternoon, US overlap prefered  

--- a/main/2023/CG-10.md
+++ b/main/2023/CG-10.md
@@ -69,7 +69,7 @@ There will likely be some catering provided by Google. Details are to be defined
 - Initial work on a DSL for the specification document
   - 40 mins (Andreas Rossberg, Sukyoung Ryu, Conrad Watt)
   - Prefer Wednesday, October 11th
-- Update on [threads proposal](https://github.com/WebAssembly/threads) (with phase 4 vote?)
+- Update on [threads proposal](https://github.com/WebAssembly/threads) (with possible phase 4 vote)
   - 30 mins (Conrad Watt)
   - Any day after 3pm Munich time
 - Post-MVP threads discussion


### PR DESCRIPTION
A first attempt at a schedule for the meeting next week: 
 - This prioritizes Phase advancements, and dependencies
 - Most updates are scheduled for the second day, I expect there will be some overflow into the second day