### PR TITLE
Update CG-10

### DIFF
--- a/main/2023/CG-10.md
+++ b/main/2023/CG-10.md
@@ -74,8 +74,6 @@ Please add any scheduling constraints here, especially if you're not able to tra
   - To end before 12pm Munich time, either day
 - Exception handling: Vote on [the proposed spec for reintroducing exnref](https://github.com/WebAssembly/exception-handling/issues/281)
   - 30 mins (Heejin Ahn, Ben Titzer)
-- Implementation report of memory.discard in SpiderMonkey
-  - 30 mins (Ryan Hunt)
 - Spritely's use of GC as a target for Scheme compilation
   - 45 mins (Andy Wingo)
 - Wasm_of_ocaml: compiling OCaml bytecode to WasmGC
@@ -90,7 +88,7 @@ Please add any scheduling constraints here, especially if you're not able to tra
 - Extended Name Section: Update and discussion on [name declarations](https://github.com/WebAssembly/annotations/issues/21)
   - 15 mins (Ashley Nelson)
 - Memory control: Proposal update
-  - 30 mins (Deepti Gandluri)
+  - 45 mins (Deepti Gandluri, Ryan Hunt)
 - Profile Guided Optimization hints: Pre-proposal discussion
   - 30 mins (Emanuel Ziegler)
 

--- a/main/2023/CG-10.md
+++ b/main/2023/CG-10.md
@@ -91,6 +91,8 @@ Please add any scheduling constraints here, especially if you're not able to tra
   - 45 mins (Deepti Gandluri, Ryan Hunt)
 - Profile Guided Optimization hints: Pre-proposal discussion
   - 30 mins (Emanuel Ziegler)
+- JS string builtins proposal update
+  - 30 minutes (Ryan Hunt)
 
 ## Meeting notes
 To be added after the meeting.


### PR DESCRIPTION
 - Merge the memory-control related presentations into one slot (from a discussion with @dtig, we expect 45 minutes to be enough).
 - Give a proposal update on JS string builtins (no phase vote)