### PR TITLE
Add agenda item to WASI-10-19 for changing WASI acronym expansion

### DIFF
--- a/wasi/2023/WASI-10-19.md
+++ b/wasi/2023/WASI-10-19.md
@@ -27,4 +27,4 @@ The meeting will be on a zoom.us video conference.
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Submit a PR to add your announcement here_
+    1. Discussion and poll for reframing WASI to stand for "WebAssembly Standard Interfaces" (Luke Wagner, 15min)


### PR DESCRIPTION
The discussion, followed by a poll, is for the idea to change WASI from standing for "WebAssembly System Interface" to instead stand for "WebAssembly Standard Interfaces".  This idea has already been presented and discussed positively around the broader community, so this is an agenda item to consider making the change more formally.