### PR TITLE
Cancel October 24th due to lack of agenda

### DIFF
--- a/main/2023/CG-10-24.md
+++ b/main/2023/CG-10-24.md
@@ -1,0 +1,30 @@
+![WebAssembly logo](/images/WebAssembly.png)
+
+## Agenda for the May 9th video call of WebAssembly's Community Group
+
+- **Where**: zoom.us
+- **When**: October 24th, 4pm-5pm UTC (October 24th, 9am-10am Pacific Time)
+- **Location**: *link on calendar invite*
+
+### Registration
+
+None required if you've attended before. Send an email to the acting [WebAssembly CG chair](mailto:webassembly-cg-chair@chromium.org)
+to sign up if it's your first time. The meeting is open to CG members only.
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+Installation is required, see the calendar invite.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Opening of the meeting
+    1. Introduction of attendees
+1. Find volunteers for note taking (acting chair to volunteer)
+1. Proposals and discussions
+1. Closure
+
+## Meeting Notes
+
+*Meeting cancelled due to lack of agenda*


### PR DESCRIPTION
Carryover items from the in-person meeting are scheduled for Nobember 7