### PR TITLE
WASI: add meeting files for 2024

### DIFF
--- a/wasi/2024/WASI-01-11.md
+++ b/wasi/2024/WASI-01-11.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: January 11 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: January 11 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-01-25.md
+++ b/wasi/2024/WASI-01-25.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: January 25 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: January 25 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-02-08.md
+++ b/wasi/2024/WASI-02-08.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: February 08 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: February 08 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-02-22.md
+++ b/wasi/2024/WASI-02-22.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: February 22 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: February 22 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-03-07.md
+++ b/wasi/2024/WASI-03-07.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: March 07 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: March 07 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-03-21.md
+++ b/wasi/2024/WASI-03-21.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: March 21 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: March 21 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-04-04.md
+++ b/wasi/2024/WASI-04-04.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: April 04 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: April 04 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-04-18.md
+++ b/wasi/2024/WASI-04-18.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: April 18 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: April 18 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-05-02.md
+++ b/wasi/2024/WASI-05-02.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: May 02 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: May 02 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-05-16.md
+++ b/wasi/2024/WASI-05-16.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: May 16 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: May 16 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-05-30.md
+++ b/wasi/2024/WASI-05-30.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: May 30 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: May 30 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-06-13.md
+++ b/wasi/2024/WASI-06-13.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: June 13 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: June 13 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-06-27.md
+++ b/wasi/2024/WASI-06-27.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: June 27 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: June 27 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-07-11.md
+++ b/wasi/2024/WASI-07-11.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: July 11 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: July 11 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-07-25.md
+++ b/wasi/2024/WASI-07-25.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: July 25 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: July 25 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-08-08.md
+++ b/wasi/2024/WASI-08-08.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: August 08 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: August 08 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-08-22.md
+++ b/wasi/2024/WASI-08-22.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: August 22 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: August 22 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-09-05.md
+++ b/wasi/2024/WASI-09-05.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: September 05 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: September 05 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-09-19.md
+++ b/wasi/2024/WASI-09-19.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: September 19 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: September 19 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-10-03.md
+++ b/wasi/2024/WASI-10-03.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: October 03 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: October 03 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-10-17.md
+++ b/wasi/2024/WASI-10-17.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: October 17 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: October 17 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-10-31.md
+++ b/wasi/2024/WASI-10-31.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: October 31 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: October 31 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-11-14.md
+++ b/wasi/2024/WASI-11-14.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: November 14 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: November 14 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-11-28.md
+++ b/wasi/2024/WASI-11-28.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: November 28 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: November 28 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2024/WASI-12-12.md
+++ b/wasi/2024/WASI-12-12.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: December 12 WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: December 12 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/README.md
+++ b/wasi/README.md
@@ -7,6 +7,38 @@ Meetings of the WASI Subgroup of the W3C WebAssembly Community Group (CG) follow
 
 <details open>
 
+<summary>2024</summary>
+
+  * [WASI January 11th video call](2024/WASI-01-11.md)
+  * [WASI January 25th video call](2024/WASI-01-25.md)
+  * [WASI February 8th video call](2024/WASI-02-08.md)
+  * [WASI February 22 video call](2024/WASI-02-22.md)
+  * [WASI March 7th video call](2024/WASI-03-07.md)
+  * [WASI March 21st video call](2024/WASI-03-21.md)
+  * [WASI April 4th video call](2024/WASI-04-04.md)
+  * [WASI April 18th video call](2024/WASI-04-18.md)
+  * [WASI May 2nd video call](2024/WASI-05-02.md)
+  * [WASI May 16th video call](2024/WASI-05-16.md)
+  * [WASI May 30th video call](2024/WASI-05-30.md)
+  * [WASI June 13th video call](2024/WASI-06-13.md)
+  * [WASI June 27th video call](2024/WASI-06-27.md)
+  * [WASI July 11th video call](2024/WASI-07-11.md)
+  * [WASI July 25th video call](2024/WASI-07-25.md)
+  * [WASI August 8th video call](2024/WASI-08-08.md)
+  * [WASI August 22nd video call](2024/WASI-08-22.md)
+  * [WASI September 5th video call](2024/WASI-09-05.md)
+  * [WASI September 19th video call](2024/WASI-09-19.md)
+  * [WASI October 3rd video call](2024/WASI-10-03.md)
+  * [WASI October 17th video call](2024/WASI-10-17.md)
+  * [WASI October 31st video call](2024/WASI-10-31.md)
+  * [WASI November 14th video call](2024/WASI-11-14.md)
+  * [WASI November 28th video call](2024/WASI-11-28.md)
+  * [WASI December 12th video call](2024/WASI-12-12.md)
+
+</details>
+
+<details open>
+
 <summary>2023</summary>
 
   * [WASI January 12th video call](2023/WASI-01-12.md)

--- a/wasi/TEMPLATE.md
+++ b/wasi/TEMPLATE.md
@@ -1,0 +1,31 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: {month} {day} WASI video call
+
+- **Where**: zoom.us (see Registration below)
+- **When**: {month} {day} 2024, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Pat Hickey and Bailey Hayes
+  - Email: phickey@fastly.com and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
+
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/gen-agendas
+++ b/wasi/gen-agendas
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import argparse, os
+from datetime import date, datetime, timedelta
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog = 'gen-agendas',
+        description = 'Generate meeting templates',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument(
+        '--start',
+        required=True,
+        help='The first meeting day')
+
+    parser.add_argument(
+        '--frequency',
+        required=False,
+        default=7,
+        help='The frequency that this meeting happens in units of days. Default is weekly.')
+
+    parser.add_argument(
+        '--num',
+        required=False,
+        default=10,
+        help='The number of meetings to generate')
+
+    parser.add_argument(
+        '--template',
+        required=True,
+        help='''
+            The template to use. Can use `{{month}}` and `{{day}}`-style formats. For
+            example, `./cranelift/TEMPLATE.md`.
+        ''')
+
+    parser.add_argument(
+        '--filename-template',
+        required=True,
+        help='''
+            How to generate filenames for meeting agenda files. For example
+            `./cranelift/%%Y/cranelift-%%m-%%d.md` will generate files like e.g
+            `./cranelift/2023/cranelift-02-08.md`
+        ''')
+
+    args = parser.parse_args()
+
+    start = datetime.strptime(args.start, '%Y-%m-%d').date()
+
+    with open(args.template, 'r') as f:
+        template = f.read()
+
+
+    for i in range(0, int(args.num)):
+        d = start + timedelta(days=i * int(args.frequency))
+
+        path = d.strftime(args.filename_template)
+        directory = os.path.dirname(path)
+        os.makedirs(directory, exist_ok=True)
+
+        with open(path, 'w') as f:
+            agenda = template.format(month=d.strftime('%B'), day=d.strftime('%d'))
+            f.write(agenda)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The cadence continues according to our google calendar event.

I changed the template slightly to emphasize that you need to sign up for the CG and appear on the participants list before registering, because I field those by hand and a large portion of registrants miss that requirement.

I pulled in the gen-agendas script from
https://github.com/bytecodealliance/meetings and then executed

```
./gen-agendas --start 2024-1-11 --template TEMPLATE.md --filename-template 2024/WASI-%m-%d.md --frequency 14 --num 25
```