### PR TITLE
2024 Jan 25: schedule wasi-observe phase 1 proposal

### DIFF
--- a/wasi/2024/WASI-01-25.md
+++ b/wasi/2024/WASI-01-25.md
@@ -29,3 +29,9 @@ The meeting will be on a zoom.us video conference.
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
     1. _Submit a PR to add your announcement here_
+    1. New proposal: wasi-observe
+        1. Issue: https://github.com/WebAssembly/WASI/issues/573
+        1. Proposal repo: https://github.com/dylibso/wasi-observe
+        1. Call for participants: https://github.com/dylibso/wasi-observe/issues/1
+        1. Any initial feedback?
+        1. Vote: Approve for Phase 1


### PR DESCRIPTION
Per https://github.com/WebAssembly/WASI/issues/573, requesting an agenda item to discuss `wasi-observe` on Jan 25. (I'd schedule it for Jan 11, but I saw that the preview 2 vote is on the 11th and wanted to give that more time. If you'd prefer I move this item up, I'd be happy to do so, though!)

Thanks for your consideration!