### PR TITLE
Proposed charter for WebAssembly benchmarking

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -39,6 +39,13 @@ The Subgroup may produce software related to benchmarking of WebAssembly, includ
 
 - Benchmarking tools specifically designed for WebAssembly
 - Libraries or frameworks to aid in the benchmarking of WebAssembly applications
+- Distilling and collating WebAssembly benchmarking suites. 
+
+### Specifications
+
+The Subgroup may produce amendments and extensions to existing WebAssembly
+proposals or propose the creation of new proposals leading to better
+instrospection (e.g profiling/tracing) for WebAssembly. 
 
 ## Amendments to this Charter and Chair Selection
 

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -1,0 +1,45 @@
+# WebAssembly Benchmarking Subgroup Charter
+
+The Benchmarking Subgroup is a sub-organization of the [WebAssembly Community
+Group](https://www.w3.org/community/webassembly/) of the W3C. As such, it is
+intended that its charter align with that of the CG. In particular, the sections
+of the [CG charter](https://webassembly.github.io/cg-charter/) relating to
+[Community and Business Group
+Process](https://webassembly.github.io/cg-charter/#process), [Contribution
+Mechanics](https://webassembly.github.io/cg-charter/#contrib),
+[Transparency](https://webassembly.github.io/cg-charter/#transparency), and
+[Decision Process](https://webassembly.github.io/cg-charter/#decision) also
+apply to the Subgroup.
+
+## Goals
+
+The mission of this subgroup is to provide a forum for collaboration on
+benchmarking efforts for WebAssembly programs, sharing best practices, tools,
+and knowledge related to benchmarking.
+
+## Scope
+
+The Subgroup will consider topics related to benchmarking of WebAssembly, including:
+
+- Best practices for benchmarking WebAssembly
+- Development and sharing of benchmarking tools
+- Knowledge sharing about existing benchmarks, systems, and projects
+- Public, high-level, recommendations about best practices, frameworks, suites, metrics, for WebAssembly benchmarking
+
+## Deliverables
+
+### Non-normative reports
+
+The Subgroup may produce non-normative material such as requirements documents,
+recommendations, and use cases related to benchmarking.
+
+### Software
+
+The Subgroup may produce software related to benchmarking of WebAssembly, including but not limited to:
+
+- Benchmarking tools specifically designed for WebAssembly
+- Libraries or frameworks to aid in the benchmarking of WebAssembly applications
+
+## Amendments to this Charter and Chair Selection
+
+This charter may be amended, and Subgroup Chairs may be selected by vote of the full WebAssembly Community Group.


### PR DESCRIPTION
As discussed during the meeting on 12-19-2023, this change adds a proposed charter for the WebAssembly benchmarking subgroup. The intention is to collect feedback on the written form of the charter and call for a vote in one of the upcoming meetings.

As a side note @dtig / @dschuff: would it make sense to update https://github.com/WebAssembly/meetings/blob/main/process/subgroups.md#subgroups to reflect that the process of creating a subgroup ideally requires a written version of the charter via a PR in this repository, some time before discussing the creation of the subgroup in a meeting? During today's meeting, that seemed to be what most of the attendees referred to as a best practice, but I couldn't find it documented anywhere. I'd be happy to make that addition if you think it's worth it, and it'll hopefully make the process a bit clearer for future subgroups. 