### PR TITLE
WASI: Reschedule vote for WASI Preview 2 launch from 1/11 to 1/25

### DIFF
--- a/wasi/2024/WASI-01-11.md
+++ b/wasi/2024/WASI-01-11.md
@@ -28,4 +28,5 @@ The meeting will be on a zoom.us video conference.
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. Vote: launching WASI Preview 2
+    1. Guy Bedford: JCO progress update
+    1. Open Q&A: launching WASI Preview 2, vote to follow on 01/25

--- a/wasi/2024/WASI-01-25.md
+++ b/wasi/2024/WASI-01-25.md
@@ -28,7 +28,8 @@ The meeting will be on a zoom.us video conference.
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Submit a PR to add your announcement here_
+    1. Guy Bedford: JCO progress update
+    1. Vote: launching WASI Preview 2
     1. New proposal: wasi-observe
         1. Issue: https://github.com/WebAssembly/WASI/issues/573
         1. Proposal repo: https://github.com/dylibso/wasi-observe


### PR DESCRIPTION
On 1/11, @gbedford will give an update on the JCO implementation progress, which is close to completion.

On 1/25, we will hear about the conclusion of the JCO implementation work, and hold the vote to launch Preview 2.

We may have to bump the wasi-observe proposal presentation and phase 1 vote to either the following meeting (WASI-02-08) or, alternatively, forward to WASI-01-11. @chrisdickinson, please let me know your preference.