### PR TITLE
reschedule wasi-observe meeting from 2024 {Jan 25 → Feb 08}

### DIFF
--- a/wasi/2024/WASI-01-25.md
+++ b/wasi/2024/WASI-01-25.md
@@ -30,9 +30,3 @@ The meeting will be on a zoom.us video conference.
 1. Proposals and discussions
     1. Guy Bedford: JCO progress update
     1. Vote: launching WASI Preview 2
-    1. New proposal: wasi-observe
-        1. Issue: https://github.com/WebAssembly/WASI/issues/573
-        1. Proposal repo: https://github.com/dylibso/wasi-observe
-        1. Call for participants: https://github.com/dylibso/wasi-observe/issues/1
-        1. Any initial feedback?
-        1. Vote: Approve for Phase 1

--- a/wasi/2024/WASI-02-08.md
+++ b/wasi/2024/WASI-02-08.md
@@ -29,3 +29,9 @@ The meeting will be on a zoom.us video conference.
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
     1. _Submit a PR to add your announcement here_
+    1. New proposal: wasi-observe
+        1. Issue: https://github.com/WebAssembly/WASI/issues/573
+        1. Proposal repo: https://github.com/dylibso/wasi-observe
+        1. Call for participants: https://github.com/dylibso/wasi-observe/issues/1
+        1. Any initial feedback?
+        1. Vote: Approve for Phase 1


### PR DESCRIPTION
Per f0f66a3238a21cea53b2c7f862f80fe462daf828, pushing the WASI Observe vote back to Feb 8th so interested participants have a chance to meet up before the proposal presentation (our initial call for participants closes on the 12th.)