### PR TITLE
Clarify time slot and presenters for 01-30

### DIFF
--- a/main/2024/CG-01-30.md
+++ b/main/2024/CG-01-30.md
@@ -23,7 +23,8 @@ Installation is required, see the calendar invite.
     1. Introduction of attendees
 1. Find volunteers for note taking (acting chair to volunteer)
 1. Proposals and discussions
-    1. Resume vote for creation of WebAssembly Benchmarking Subgroup
+    1. Resume vote for creation of WebAssembly Benchmarking Subgroup (10 mins;
+       Ben Titzer / Peter Penzin)
         1. Proposed charter: https://github.com/WebAssembly/meetings/pull/1455
     1. FP16 proposal introduction (30 mins)
 1. Closure


### PR DESCRIPTION
Just a small correction for 01-30 meeting on the time needed and the presenters.

cc @titzer @penzn as discussed offline. 