### PR TITLE
docs(wasi): link to invite form

### DIFF
--- a/wasi/README.md
+++ b/wasi/README.md
@@ -3,6 +3,8 @@
 Meetings of the WASI Subgroup of the W3C WebAssembly Community Group (CG) follow
 [the process of the CG](https://github.com/WebAssembly/meetings).
 
+If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform) to receive an invite.
+
 ## Meetings
 
 <details open>


### PR DESCRIPTION
We have this link in our agendas, adding to top-level README for additional visibility.