### PR TITLE
Add ESM integration to Feb 27 agenda

### DIFF
--- a/main/2024/CG-02-27.md
+++ b/main/2024/CG-02-27.md
@@ -1,0 +1,40 @@
+![WebAssembly logo](/images/WebAssembly.png)
+
+## Agenda for the February 13th video call of WebAssembly's Community Group
+
+- **Where**: zoom.us
+- **When**: February 13th, 5pm-6pm UTC (February 13th, 9am-10am Pacific Time)
+- **Location**: *link on calendar invite*
+
+### Registration
+
+None required if you've attended before. Send an email to the acting [WebAssembly CG chair](mailto:webassembly-cg-chair@chromium.org)
+to sign up if it's your first time. The meeting is open to CG members only.
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+Installation is required, see the calendar invite.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Opening of the meeting
+    1. Introduction of attendees
+1. Find volunteers for note taking (acting chair to volunteer)
+1. Proposals and discussions
+    1. Update and phase 3 poll for ESM Integration (Guy Bedford, 25 minutes)
+        1. Issue: https://github.com/webassembly/esm-integration
+1. Closure
+
+## Agenda items for future meetings
+
+*None*
+
+### Schedule constraints
+
+*None*
+
+## Meeting Notes
+
+To be added after the meeting.

--- a/main/2024/CG-02-27.md
+++ b/main/2024/CG-02-27.md
@@ -3,7 +3,7 @@
 ## Agenda for the February 13th video call of WebAssembly's Community Group
 
 - **Where**: zoom.us
-- **When**: February 13th, 5pm-6pm UTC (February 13th, 9am-10am Pacific Time)
+- **When**: February 27th, 5pm-6pm UTC (February 13th, 9am-10am Pacific Time)
 - **Location**: *link on calendar invite*
 
 ### Registration


### PR DESCRIPTION
It would be great to bring the Wasm ESM integration back to the CG given the recent progress with source phase imports, and to finally seek its stage 3 progression.