### PR TITLE
Cancel March 19 threads meeting

### DIFF
--- a/threads/2024/THREADS-04-02.md
+++ b/threads/2024/THREADS-04-02.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the March 19, 2024 video call of WebAssembly's Threads Subgroup
+## Agenda for the April 2, 2024 video call of WebAssembly's Threads Subgroup
 
 - **Where**: zoom.us
-- **When**: March 19, 2024, 4pm-5pm UTC (March 19, 2024, 9am-10am Pacific Time)
+- **When**: April 2, 2024, 4pm-5pm UTC (April 2, 2024, 9am-10am Pacific Time)
 - **Location**: *link on calendar invite*
 
 ### Registration


### PR DESCRIPTION
Remove the notes file for March 19 and add a file for the next meeting on April 2 instead.