### PR TITLE
agenda item for WASI-03-21: advance wasi-i2c to phase 2

### DIFF
--- a/wasi/2024/WASI-03-21.md
+++ b/wasi/2024/WASI-03-21.md
@@ -29,3 +29,4 @@ The meeting will be on a zoom.us video conference.
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
     1. Joel Dice: Proposal to add TLS interface to `wasi-sockets`
+    1. Vote: Advance `wasi-i2c` proposal to Phase 2


### PR DESCRIPTION
Current progress can be seen [here](https://github.com/WebAssembly/wasi-i2c/pull/1) and is awaiting approval of a maintainer.