### PR TITLE
WASI: change Pat Hickey's contact email to pat@moreproductive.org

### DIFF
--- a/wasi/2024/WASI-04-04.md
+++ b/wasi/2024/WASI-04-04.md
@@ -6,7 +6,7 @@
 - **When**: April 04 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-04-18.md
+++ b/wasi/2024/WASI-04-18.md
@@ -6,7 +6,7 @@
 - **When**: April 18 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-05-02.md
+++ b/wasi/2024/WASI-05-02.md
@@ -6,7 +6,7 @@
 - **When**: May 02 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-05-16.md
+++ b/wasi/2024/WASI-05-16.md
@@ -6,7 +6,7 @@
 - **When**: May 16 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-05-30.md
+++ b/wasi/2024/WASI-05-30.md
@@ -6,7 +6,7 @@
 - **When**: May 30 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-06-13.md
+++ b/wasi/2024/WASI-06-13.md
@@ -6,7 +6,7 @@
 - **When**: June 13 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-06-27.md
+++ b/wasi/2024/WASI-06-27.md
@@ -6,7 +6,7 @@
 - **When**: June 27 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-07-11.md
+++ b/wasi/2024/WASI-07-11.md
@@ -6,7 +6,7 @@
 - **When**: July 11 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-07-25.md
+++ b/wasi/2024/WASI-07-25.md
@@ -6,7 +6,7 @@
 - **When**: July 25 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-08-08.md
+++ b/wasi/2024/WASI-08-08.md
@@ -6,7 +6,7 @@
 - **When**: August 08 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-08-22.md
+++ b/wasi/2024/WASI-08-22.md
@@ -6,7 +6,7 @@
 - **When**: August 22 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-09-05.md
+++ b/wasi/2024/WASI-09-05.md
@@ -6,7 +6,7 @@
 - **When**: September 05 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-09-19.md
+++ b/wasi/2024/WASI-09-19.md
@@ -6,7 +6,7 @@
 - **When**: September 19 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-10-03.md
+++ b/wasi/2024/WASI-10-03.md
@@ -6,7 +6,7 @@
 - **When**: October 03 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-10-17.md
+++ b/wasi/2024/WASI-10-17.md
@@ -6,7 +6,7 @@
 - **When**: October 17 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-10-31.md
+++ b/wasi/2024/WASI-10-31.md
@@ -6,7 +6,7 @@
 - **When**: October 31 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-11-14.md
+++ b/wasi/2024/WASI-11-14.md
@@ -6,7 +6,7 @@
 - **When**: November 14 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-11-28.md
+++ b/wasi/2024/WASI-11-28.md
@@ -6,7 +6,7 @@
 - **When**: November 28 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 

--- a/wasi/2024/WASI-12-12.md
+++ b/wasi/2024/WASI-12-12.md
@@ -6,7 +6,7 @@
 - **When**: December 12 2024, 17:00-18:00 UTC
 - **Contact**:
   - Name: Pat Hickey and Bailey Hayes
-  - Email: phickey@fastly.com and bailey@cosmonic.com
+  - Email: pat@moreproductive.org and bailey@cosmonic.com
 
 ### Registration
 


### PR DESCRIPTION
My last day at Fastly was March 8, 2024. Apologies if you sent a mail to phickey@fastly.com after that date, I did not recieve it.