### PR TITLE
Cancel April 16 threads meeting

### DIFF
--- a/threads/2024/THREADS-04-30.md
+++ b/threads/2024/THREADS-04-30.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the April 16, 2024 video call of WebAssembly's Threads Subgroup
+## Agenda for the April 30, 2024 video call of WebAssembly's Threads Subgroup
 
 - **Where**: zoom.us
-- **When**: April 16, 2024, 4pm-5pm UTC (April 16, 2024, 9am-10am Pacific Time)
+- **When**: April 30, 2024, 4pm-5pm UTC (April 30, 2024, 9am-10am Pacific Time)
 - **Location**: *link on calendar invite*
 
 ### Registration


### PR DESCRIPTION
For lack of agenda. Add an agenda for April 30.