### PR TITLE
Copy code of conduct to meetings repo

### DIFF
--- a/CODE_OF_CONDUCT
+++ b/CODE_OF_CONDUCT
@@ -1,0 +1,66 @@
+# Code of Ethics and Professional Conduct
+
+WebAssembly operates under the W3C's
+[Code of Ethics and Professional Conduct][]:
+
+> W3C is a growing and global community where participants choose to work
+> together, and in that process experience differences in language, location,
+> nationality, and experience. In such a diverse environment, misunderstandings
+> and disagreements happen, which in most cases can be resolved informally. In
+> rare cases, however, behavior can intimidate, harass, or otherwise disrupt one
+> or more people in the community, which W3C will not tolerate.
+>
+> A Code of Ethics and Professional Conduct is useful to define accepted and
+> acceptable behaviors and to promote high standards of professional
+> practice. It also provides a benchmark for self evaluation and acts as a
+> vehicle for better identity of the organization.
+
+We hope that our community group act according to these guidelines, and that
+participants hold each other to these high standards.
+
+If you are worried that the code isn't being followed, or are witness to a violation
+but are uncomfortable speaking up, please contact the Community Group's chairs at
+`team-wasm-chairs@w3.org` (note: this list is also visible to W3C staff).
+
+In cases where there is repeated disregard for the CEPC, it is possible to incur disciplinary
+action. The points below outline a series of steps that will be taken in case of violations
+to ensure a positive work environment in the WebAssembly CG.
+
+ - **Informal warning**
+   An informal or verbal warning can be issued in any relevant medium of communication calling
+   out inappropriate behavior as a violation of the CEPC
+   (examples: responses to github issues or PRs, discord, email, meetings).
+
+ - **Corrective action and/or counseling**
+   Informal meetings, or email discussions where problematic behavior is addressed,
+   and suggestions for constructive ways forward are offered. A mediation process can also be an
+   option if relevant to the situation and both parties agree.
+
+ - **Formal warning**
+   An explicit warning issued after repeated incidents. While members of the CG can call out
+   inappropriate behavior as needed, warnings will be issued by CG chairs, subgroup chairs, or
+   proposal champions depending on the nature of the violation. The warning should be issued
+   with consultation from team-wasm-chairs@w3.org.
+
+ - **Optional formal meeting**
+   An optional meeting with the chairs and/or a W3C representative to discuss next steps.
+   The meeting can be requested by any party, and should serve as a forum for discussion.
+   While this is the recommended next step, it is not a blocker for further action, i.e.
+   the chairs can request that a meeting take place, and should be available for a
+   discussion if requested by others, but further action will not be gated on this meeting.
+
+ - **Temporary suspension**
+   The temporary suspension will be issued based on repeat violations,
+   with the duration and the reason for the suspension clearly outlined.
+
+ - **Indefinite suspension, revoking membership etc.**
+
+The set of actions above are an edited version of the W3C [disciplinary process][] as
+applicable to the Wasm CG, and will be carried out with respect, confidentiality, and fairness.
+
+The W3C also has [procedures][],
+allowing you to access its ombuds directly and confidentially, in case other venues of resolution have not resulted in a satisfactory outcome.
+
+  [Code of Ethics and Professional Conduct]: https://www.w3.org/Consortium/cepc
+  [procedures]: https://www.w3.org/Consortium/pwe/#Procedures
+  [disciplinary process]: https://github.com/w3c/PWETF/blob/main/CEPCdisciplinary-process.md


### PR DESCRIPTION
Copy the WebAssembly code of conduct, currently hosted at https://github.com/WebAssembly/design/blob/main/CodeOfConduct.md, from the design repo to the meetings repo.

The documents in the design repo are largely out of date and of historical interest only, while the documents in the meetings repo are current, so the meetings repo is a much better place for the code of conduct.

Add the code of conduct in a top-level CODE_OF_CONDUCT file instead of in the process directory to 1) make it even more visible, and 2) take advantage of GitHub's native support for codes of conduct.

If this seems like a good direction, the next step would be to update other repos in our organization with code of conduct files that redirect to this canonical file.