### PR TITLE
Add CG meeting templates for the rest of 2024

### DIFF
--- a/main/2024/CG-05-21.md
+++ b/main/2024/CG-05-21.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the May 21st video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-05-21, 16:00-17:00 UTC (2024-05-21, 9am-10am PDT, 18:00-19:00 CEST)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration
@@ -14,6 +14,7 @@ No registration is required for VC meetings. The meeting is open to CG members o
 
 1. Opening
 1. Proposals and discussions
+    1. Discussion of [the `custom-page-sizes` proposal](https://github.com/WebAssembly/custom-page-sizes) and vote for phase 2 (Nick Fitzgerald, 45 minutes)
 1. Closure
 
 ## Agenda items for future meetings

--- a/main/2024/CG-06-18.md
+++ b/main/2024/CG-06-18.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the June 18th video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-06-18, 16:00-17:00 UTC (2024-06-18, 9am-10am PDT, 18:00-19:00 CEST)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-07-02.md
+++ b/main/2024/CG-07-02.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the July 2nd video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-07-02, 16:00-17:00 UTC (2024-07-02, 9am-10am PDT, 18:00-19:00 CEST)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-07-16.md
+++ b/main/2024/CG-07-16.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the July 16th video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-07-16, 16:00-17:00 UTC (2024-07-16, 9am-10am PDT, 18:00-19:00 CEST)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-07-30.md
+++ b/main/2024/CG-07-30.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the July 30th video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-07-30, 16:00-17:00 UTC (2024-07-30, 9am-10am PDT, 18:00-19:00 CEST)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-08-13.md
+++ b/main/2024/CG-08-13.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the August 13th video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-08-13, 16:00-17:00 UTC (2024-08-13, 9am-10am PDT, 18:00-19:00 CEST)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-08-27.md
+++ b/main/2024/CG-08-27.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the August 27th video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-08-27, 16:00-17:00 UTC (2024-08-27, 9am-10am PDT, 18:00-19:00 CEST)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-09-10.md
+++ b/main/2024/CG-09-10.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the September 10th video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-09-10, 16:00-17:00 UTC (2024-09-10, 9am-10am PDT, 18:00-19:00 CEST)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-09-24.md
+++ b/main/2024/CG-09-24.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the September 24th video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-09-24, 16:00-17:00 UTC (2024-09-24, 9am-10am PDT, 18:00-19:00 CEST)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-10-08.md
+++ b/main/2024/CG-10-08.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the October 8th video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-10-08, 16:00-17:00 UTC (2024-10-08, 9am-10am PDT, 18:00-19:00 CEST)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-10-22.md
+++ b/main/2024/CG-10-22.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the October 22 video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-10-22, 16:00-17:00 UTC (2024-10-22, 9am-10am PDT, 18:00-19:00 CEST)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-11-05.md
+++ b/main/2024/CG-11-05.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the 2024-04-30 video call of WebAssembly's Community Group
+## Agenda for the November 5th video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-04-30, 16:00-17:00 UTC (2024-04-30, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-11-05, 17:00-18:00 UTC (2024-11-05, 9am-10am PST, 18:00-19:00 CET)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-11-19.md
+++ b/main/2024/CG-11-19.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the November 19th video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-11-19, 17:00-18:00 UTC (2024-11-19, 9am-10am PST, 18:00-19:00 CET)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-12-03.md
+++ b/main/2024/CG-12-03.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the December 3rd video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-12-03, 17:00-18:00 UTC (2024-12-03, 9am-10am PST, 18:00-19:00 CET)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-12-17.md
+++ b/main/2024/CG-12-17.md
@@ -1,9 +1,9 @@
 ![WebAssembly logo](/images/WebAssembly.png)
 
-## Agenda for the May 7th video call of WebAssembly's Community Group
+## Agenda for the December 17th video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-05-07, 16:00-17:00 UTC (2024-05-07, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-12-17, 17:00-18:00 UTC (2024-12-17, 9am-10am PDT, 18:00-19:00 CEST)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration

--- a/main/2024/CG-12-17.md
+++ b/main/2024/CG-12-17.md
@@ -3,7 +3,7 @@
 ## Agenda for the December 17th video call of WebAssembly's Community Group
 
 - **Where**: Virtual meeting
-- **When**: 2024-12-17, 17:00-18:00 UTC (2024-12-17, 9am-10am PDT, 18:00-19:00 CEST)
+- **When**: 2024-12-17, 17:00-18:00 UTC (2024-12-17, 9am-10am PST, 18:00-19:00 CET)
 - **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/) or Google Calendar invitation*
 
 ### Registration


### PR DESCRIPTION
No meetings scheduled for June 4 or December 31.
Also remove April 30 and move page size discussion to May 21