### PR TITLE
Schedule update on Branch Hinting on CG-05-07 

### DIFF
--- a/main/2024/CG-05-07.md
+++ b/main/2024/CG-05-07.md
@@ -14,6 +14,7 @@ No registration is required for VC meetings. The meeting is open to CG members o
 
 1. Opening
 1. Proposals and discussions
+   1. [Branch Hinting](https://github.com/WebAssembly/branch-hinting) Update about [new spec document](https://webassembly.github.io/branch-hinting/metadata/code/) for Code Metadata (Yuri Iozzelli, 15 minutes)
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
I would like to give a brief update on the new spec document (preview: https://webassembly.github.io/branch-hinting/metadata/code/)  for Code Metadata sections.