### PR TITLE
Add @tomayac's time constraints for CG meeting

### DIFF
--- a/main/2024/CG-06.md
+++ b/main/2024/CG-06.md
@@ -96,6 +96,7 @@ Vote on intent to use the DSL to author the official spec
 
 #### WebAssembly.org Makeover
 Discussion of goals for website refresh
+- schedule on 5th (earlier for EU/US overlap hours)
 
 ## Meeting notes
 To be added after the meeting


### PR DESCRIPTION
I proposed the [webassembly.org session](https://github.com/WebAssembly/meetings/blob/main/main/2024/CG-06.md#webassemblyorg-makeover:~:text=WebAssembly.org%20Makeover,for%20website%20refresh), but can only be there on June 5th (and the research day), but not the 6th.