### PR TITLE
Discuss `@since` and `@feature` in WASI 2024-05-30

### DIFF
--- a/wasi/2024/WASI-05-30.md
+++ b/wasi/2024/WASI-05-30.md
@@ -26,6 +26,7 @@ The meeting will be on a zoom.us video conference.
     1. Please help take notes.
     1. Thanks!
 1. Announcements
-    1. _Submit a PR to add your announcement here_
+    1. Yosh Wuyts: `@since` and `@feature` gates have landed on the Component Model ([link](https://github.com/WebAssembly/component-model/pull/332))
 1. Proposals and discussions
-    1. _Submit a PR to add your announcement here_
+    1. Yosh Wuyts: Leveraging the `@since` and `@feature` gates in WASI
+    1. Yosh Wuyts: Extending `wasi:clocks` with `timezone` support


### PR DESCRIPTION
Adds one announcement and two discussion topics to tomorrow's WASI agenda. I'd like to present the new Component Model `@feature` and `@since` gates to the WASI SG. This is intended to be informational only (e.g. nothing to vote on). Thanks!