### PR TITLE
Add agenda item to WASI 2024-06-13

### DIFF
--- a/wasi/2024/WASI-06-13.md
+++ b/wasi/2024/WASI-06-13.md
@@ -28,4 +28,4 @@ The meeting will be on a zoom.us video conference.
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Submit a PR to add your announcement here_
+    1. Yosh Wuyts: Progressing proposal amendments through the phase process


### PR DESCRIPTION
Two weeks ago we discussed the mechanics of the `@since` and `@feature` gates, and how they could be leveraged in WASI - providing concrete examples along the way. In it we discussed how amendments should probably start at stage 0, and vote from there to move it through the advancement criteria when they have been met.

Trying to put this into practice since has surfaced an interesting insight: any amendment of an existing WASI proposal definitionally already meets the phase 2 criteria by virtue of being part of a parent proposal. I want to take some time during the next meeting to expand on what that means, how we should expect amendments to proposals to advance through the stage process, and provide practical examples along the way.