### PR TITLE
WASI: add 'build targets' agenda item

### DIFF
--- a/wasi/2024/WASI-06-13.md
+++ b/wasi/2024/WASI-06-13.md
@@ -29,3 +29,4 @@ The meeting will be on a zoom.us video conference.
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
     1. Yosh Wuyts: Progressing proposal amendments through the phase process
+    2. Luke Wagner: Adding core wasm "build targets" to the Component Model


### PR DESCRIPTION
This will mostly just be re-presenting the "build-target" part of the [CG presentation last week](https://docs.google.com/presentation/d/1Y-R2fsvsurfT1cpKMvxERnqAPvWlLgiEESiheUj-QUY) for more visibility and feedback.