### PR TITLE
Add meeting notes from WG 2024-06-12

### DIFF
--- a/main/2024/WG-06-12.md
+++ b/main/2024/WG-06-12.md
@@ -42,3 +42,215 @@ None.
 None.
 
 ## Meeting Notes
+
+## Meeting Notes
+
+### Attendees
+
+ - Mike Smith
+ - Derek Schuff
+ - Luke Wagner
+ - Thomas Lively
+ - Ms2ger
+ - Andreas Rossberg
+ - Bailey Hayes
+ - Ryan Hunt
+
+
+DS: Previously we talked about what it would take to move the current spec to a CR, and worked out some publication pipeline issues on our end.  I found https://www.w3.org/Guide/transitions/?cr=draft&profile=CR listing requirements.
+ 
+MS: https://www.w3.org/2023/Process-20231103/#transition-cr is the normative document. The other has an amplified checklist that expands on the normative requirements.
+One thing I’m unclear on, is that I noticed that we must specify a deadline for comments. As far as I understand, we can keep the document in CR forever. We have this idea of  evergreen CR, which means we just assert that we don’t plan to take the document to REC status. In that case, I think that we don’t need to provide a date for when we transition out. I’ll have to ask about the details for that.
+
+AR: Can we just make up a deadline as a fallback?
+
+MS: right, if we do state a deadline it just needs to be 28 days out. In the first doc, I don’t see anything about the date in there. So either we omit it completely or just set some arbitrary date.
+
+AR: Whatever is fastest.
+
+MS: all that said, the thing that is required, the group has to be explicitly asked in some way. However we record formal decisions from the group. Send out a notification, give 2 weeks for objections, and say silence is agreement. But we do have to give the opportunity to express support or objections.
+
+
+DS: We typically record formal decisions in the meeting notes, so maybe we'll just copy and paste those.
+
+MS: one other thing about the decision: if you look at the charter wording, it we have boilerplate language about this:
+
+> "To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional. A call for consensus (CfC) will be issued for all resolutions (for example, via email and/or web-based survey), with a response period from one week to 10 working days, depending on the chair's evaluation of the group consensus on the issue."
+
+So it seems like we do have to do that, according to the charter requirements. We can only provisionally make the decision here.
+
+
+MS: another thing I’m remembering, why this is important, why a member org might want to object (even unlikely), is that when we transition to CR it triggers process steps around patent disclosure opportunities. So it may be something that lawyers at companies might want a heads-up about. I’m not sure but I’ll look for that right now. If so, that’s why it would be important that all the member companies know what’s going on.
+
+AR: Do we have obvious owners for all steps that need to be taken?
+
+DS: so, a list of the steps:
+CfC: DS
+2nd notification: DS
+...
+
+DS: Actually, can we put the implementation experience documentation in the notice? Mike, what form do the implementation experience and notifications take?
+
+MS: we do write the text in the formal transition request that I would send to the director (now we have a different org structure) but I send the formal request, but that’s the only place we need these details. I’ll just copy from where I’ve done it before. There are no requirements for what we send out to the group. Something like, does anyone object to transitioning to CR. there’s boilerplate there too making it clear that if there are no objections, silence is  taken as agreement. Other than that, no requirements.
+
+DS: Does that go in the CfC or the second notification?
+
+MS: There is only one that goes to the group: the CfC. Could be just one or 2 sentences
+
+AR: After these two periods are over and it's in CR, we're done? Or is there something else after that?
+
+DS: My understanding is that we want to stay in the permanent evergreen CR state.
+
+MS: and in that case theres nothing more as far as formal requirements
+
+MS2ger: so after that, do we push directly from CI for every change?
+
+MS: right we don’t have to do working drafts, we have a TR document just like we do now, and continuously update it. There’s no process for publication, limitations that prevent us from doing that.
+
+AR: the only reason we might want to do versioning, we can discuss that another time.
+
+MS: yeah the versioning thing can be kind of a pain, just for those of us that have to deal with the publication, that’s a one time cost, just making sure we have the old spec in the right  place, the frozen version at whatever point we freeze it, and getting it updated.
+
+TL: IIUC it was the TR that we just push to continuously from CI, but it’s the CR that’s this evergreen thing. How do changes get into the CR?
+
+MS: The CR URL is the same as the TR, we don’t change it. We have 2 things: these dated versions (i.e. there’s an actual date substring in the URL) but the tr/wasm-{version} is essentially a symlink to some dated version, so that the URL doesn’t change when the dated versions change but the contents change
+
+TL: so the whole notification thing, we do that once, and then we change the contents as they come in.
+
+MS: exactly.
+
+LW: The CR URL has the version number "2" in it, right?
+
+MS: right, if we’re versioning then that’s what we do. Call it 2 and that’s something I’ll talk with the person on staff, that’s the one thing in I can’t do myself, there’s just one person who updates things in the tr/ space, i can request that the URL gets set up, as a one-time thing
+
+LW: To Andreas's point, if we wanted to switch the version to 3, we would have to go through the process again to get a new URL with a "3" in it. Is there anything we should do to get the number just in the doc instead so that we can live push version changes in the doc without going through the process?
+
+MS: we can do that. We have tr/wasm but actually looking at that right now, it doesn’t exist. Everytime it’s been published, its with a version substring
+
+LW: so we could make the unversioned URL be the evergreen URL?
+
+
+MS: we could do that. It’s a WG choice if we want that unversioned substring to point to the latest version. BTW are we only transitioning the core spec (not JS API etc?)
+
+AR: All of them.
+
+MS: Ok, we can do the same for all of them. We have to make it clear in the process precisely which documents are going to CR.
+
+Ms2ger (chat): https://www.w3.org/TR/wasm-core/
+
+LW: from the link in chat, there is an unversioned TR link. Do we just get an unversioned CR link?
+
+Ms2ger: All specs are under TR/. There is no CR/.
+
+MS: “TR” just means “technical report”. you can just think of “TR” as shorthand for “standard” it’s just wan abbreviation we use for standards, there’s no CR URLs. I was just looking for e.g. wasm-core. So we do already have these unversioned URLs and we can indicate to W3C where we want those symlinks to point to.
+
+DS: it sounds like we do want to use the unversioned link then, right?
+
+[general agreement]
+
+DS: OK.
+
+TL: if the URL always has TR in it, then if we go to CR, the doc just says that somewhere?
+
+MS: yes. This is an implementation detail, but we don't need to manually change anything because the generator that adds the boilerplate also adds the "working draft" or "candidate recommendation" or whatever string.
+
+AR: so when we go to evergreen, we should change it to no longer say “working draft” but make it say “canidate recommendation” to make the status clear?
+
+MS: yes.
+
+AR: do you do that manually?
+
+MS: we can. I forget whether bikeshed does it automatically, but you can just set a status field and bikeshed just spits it out the right way.
+Btw to what TL just asked: bikeshed does generate a dated URL for us. And it does include along with it, it’s prefixed with cr- it’s part of the path portion that comes after the tr. so something like tr/cr-{date} is what the symlink points to. So those dated URLs will be visible. Its just a thing that we flip a bit and the publication pipeline takes care of it.
+
+AR: our makefile for the bikeshed target uses an environment variable? But I don’t see where that gets defined.
+
+MS: I think that's something I messed around with. I was setting that environment var manually. Can't recall why I did it that way. We could hard-code it in the makefile.
+
+AR: it makes sense to have it as a variable, but maybe we want to define it in the makefile.
+
+MS: I will go in and try it. I don't remember why it's that way.
+
+AR: what are valid values for status then?
+
+MS: "WD", "CR", and "REC" for groups that want to go to recommendation. Also "LS" and maybe "LS/CR" or something like that. These are discrete values that bikeshed recognizes. I can check on that.
+
+AR: What is LS/CR?
+
+MS: LS is for living standard. If it exists, LS/CR means evergreen candidate recommendation. That's what we would want to use.
+
+AR: i see in the workflow file you set the actual value includes “WG”
+
+MS: Not sure why it's in the workflow file instead of the makefile.
+
+AR: i can play around with it and see what happens. So if we try to clobber the link for the live standard in the future, we have to figure out some way to doing our internal version independently of the W3C versioning. Before we thought we might want to use a minor version, but maybe we want to bump the major version without interfering with the W3C process. For that reason it makes sense to have an unversioned link as well. We can hide away the W3C version as much as we can.
+
+MS: right. Part of that the W3C  publication process is agnostic toward but we care about that internally, but the only people who have to deal with that would be you and i and whoever is working on the publication steps. It’s just a one-time process to figure out what we want.
+
+AR: Ok, to make sure everything has an owner: I will investigate the status parameter in the makefile.
+MS, can you look into updating the unversioned link?
+
+MS: i can talk to our publication person about that. I’m looking in the bikeshed doc now, not sure I can link but if you look at the part that says “statuses useable by W3C groups” there’s no CR/LS, there’s only CR and CRD. I think we just want CR.
+
+AR: what’s a “proposed recommendation”?
+
+MS: That's another thing we don't have to care about unless we're going to REC. There's a small transitional state between CR and REC. I can’t recall why it’s that way but we don’t need to use it.
+
+DS: Ok, we have owners for the status and links. And I will send the CfC notification.
+
+Poll to send the current wasm 2.0 spec (including the JS API and web API specs) to CR, with intention to use as a living standard.
+
+SF: 6
+F: 1
+N: 0
+A: 0
+SA: 0
+
+
+
+DS: I realized yesterday that we have a bunch of proposals in phase 4, and there's nothing stopping us (the WG) from voting them to phase 5.
+
+AR: FWIW I've had a branch called wasm-3.0 that I've been using as a staging ground for merging these proposals. I've been waiting on pushing 2.0 out.
+
+DS: We can advance to phase 5 independently and before actually doing the merge. I will put that on the agenda for next month.
+
+AR: one thing I’d point out there is that most of the stage 4 proposals are in a state where i can merge them other than threads, there’s a little work left. So maybe we don’t propose that one for stage 5.
+
+That was a last-minute thing that we moved it phase 4 and it was a bit premature.
+
+TL: if we care about not moving things that were maybe premature to phase 5, with tail calls I believe that it came out that the 2nd implemetation isn’t quite complete. But the spec is fine.
+
+AR: i believe the regression has been fixed. I think they re-shipped tail calls so we should be in good shape.
+
+TL: Cool, I missed that update.
+
+RH: i’m also pretty sure that spidermonkey has tail calls now, so we should be fine.
+
+LW: There's going to be an unversioned URL and we're going to push the versioning into Wasm. We were originally going to do minor versioning, but had to move to 2.0 because of W3C process. We could go back to minor versioning now since we're not breaking things. We have 2.0 out and Andreas has been saying "3.0" a lot, so there would be some walking back, but it's worth thinking about.
+
+AR: I don't know… we’ve been calling it that for a long time, it would be quite confusing, and I’m not sure it would be buying us anything useful.
+
+LW: the future is much longer than the past.
+
+AR: it’s already embarrassing enough that it took so long, i wouldn’t want to walk it backward. What i would do instead is: it’s justified that it’s a major version because we merged so many proposals in.
+
+I would suggest that we keep bumping the major version when we merge "gamechanger" proposals like SIMD or GC. It's so much clearer if you can say "wasm 1, 2, 3", etc.
+
+LW: I guess it depends on how much semver has gotten into people’s thinking. A lot of people thing breaking changes when they see major versions
+
+AR: In a way it is breaking because it changes some properties of Wasm…
+
+LW: from a browser perspective it’s not breaking
+
+MS: there’s no limitation on the W3C side that would prevent the group from doing dot versions. The URL would have to be -11, we can’t put a dot in there. I’ve never done one with dotted versions,
+
+AR: i would stick to the unversioned URL and make that orthogonal to this discussion
+
+LW: Right, I like the unversioned URL. It's just how communicate about versions in the CG.
+
+DS: The downside of major+minor versions is that we then have to argue about what's a big enough change the major version. I would favor minor versions over major versions (or just going to integer versioning), but not a strong opinion.
+
+MS: In the body of the spec, it says 1.0. In Wasm 2.0, we could just put "2" there instead of "2.0" to avoid the appearance of semver.
+
+LW: Let's think about that in the background.
+


### PR DESCRIPTION
Including vote to send the current "2.0" spec to CR, with intention to use it as a base for a living standard going forward.