### PR TITLE
Discuss WASI release cadence on 2024-06-27

### DIFF
--- a/wasi/2024/WASI-06-27.md
+++ b/wasi/2024/WASI-06-27.md
@@ -28,4 +28,4 @@ The meeting will be on a zoom.us video conference.
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. _Submit a PR to add your announcement here_
+    1. Yosh Wuyts: Releasing non-breaking WASI versions (vote on release cadence)


### PR DESCRIPTION
### Introduction

This is the fourth presentation in the three-part series on the WASI release process. In this presentation we will present a process for releasing non-breaking WASI versions within the current 0.2 version range. **We're proposing a release train model, with a new WASI version being released every two months on the first Thursday starting in August.**

### Proposed release schedule

Under this release train model, we would see three additional non-breaking WASI releases though the end of 2024 [^2025], scheduled for the following dates:

[^2025]: Though of course releases would continue through 2025. For the sake of brevity I however have only included the 2024 dates in this table.

| WASI version | date |
| ------------ | ---- |
| 0.2.1        | 2024-08-01 |
| 0.2.2        | 2024-10-03 |
| 0.2.3        | 2024-12-05 |

### Topics of the presentation

In the presentation we will discuss the rationale behind this model, explain alternatives considered, and cover in more detail how this relates to our future plans for a WASI 0.3 release. For context on how versioning of WASI's WIT documents functions, see [WASI-05-30](https://github.com/WebAssembly/meetings/blob/main/wasi/2024/WASI-05-30.md) and [WASI-06-13](https://github.com/WebAssembly/meetings/blob/main/wasi/2024/WASI-06-13.md).

### Procedural note 
Please note that unlike the previous discussions on the topic, passing this proposal will require a subgroup vote. If any SG members would like to vote, but cannot attend themselves - I believe the standard process is to send a delegate.

Thanks!
