### PR TITLE
2024-10-08: Add a possible phase 2 vote for 128-bit-arithmetic

### DIFF
--- a/main/2024/CG-10-08.md
+++ b/main/2024/CG-10-08.md
@@ -14,6 +14,7 @@ No registration is required for VC meetings. The meeting is open to CG members o
 
 1. Opening
 1. Proposals and discussions
+   1. Update on and (possible) phase 2 vote for [128-bit-arithmetic](https://github.com/WebAssembly/128-bit-arithmetic) (Alex Crichton, 30 minutes)
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
I plan to give an update on the [state of the proposal](https://github.com/WebAssembly/128-bit-arithmetic/blob/main/proposals/128-bit-arithmetic/Overview.md) and, if applicable, vote for moving to phase 2.