### PR TITLE
[new agenda item] adding wasi-messaging proposed phase 2 vote to agenda

### DIFF
--- a/wasi/2024/WASI-11-14.md
+++ b/wasi/2024/WASI-11-14.md
@@ -28,4 +28,5 @@ The meeting will be on a zoom.us video conference.
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
-    1. Discuss `wasm32-wasip2-module` proposal ([Stephen Berard](https://github.com/srberard), 20 min)
+   1. Present wasi-messaging for proposed Phase 2 vote - @danbugs, @thomastaylor312
+   1. Discuss `wasm32-wasip2-module` proposal ([Stephen Berard](https://github.com/srberard), 20 min)


### PR DESCRIPTION
Note, I am adding it as the first agenda item because @thomastaylor312 can only attend the beginning of this meeting (hope that's ok, cc: @srberard ).