### PR TITLE
add promise-calling item to stacks agenda

### DIFF
--- a/stack/2024/stack-2024-12-04.md
+++ b/stack/2024/stack-2024-12-04.md
@@ -12,5 +12,6 @@
 
 1. Discuss issue #56 (Francis McCabe)
 1. Discussion around bringing JSPI to phase 4. (Francis McCabe)
+1. [Revisiting "promise-calling" & requiring native Promises for suspending functions](https://github.com/WebAssembly/js-promise-integration/issues/56) (Kevin Gibbons)
 
 ## Discussion


### PR DESCRIPTION
cc @fgmccabe

Possibly this is what the "Discuss issue #56" item is supposed to be? But in [the PR](https://github.com/WebAssembly/meetings/pull/1697#discussion_r1843106341) it was a different item.