### PR TITLE
docs: update links to meeting process pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ may be helpful.
 
 Meeting process is documented:
 
-* [Attendance](process/attendance.md)
-* [Day-of](process/day-of.md)
+* [Virtual Meetings](process/vc-meetings.md)
+* [In-person Meetings](process/inperson-meetings.md)
 * [Consensus](process/consensus.md)
-* [Hosting](process/hosting.md)
 
 ## Meetings
+
 <details open>
 <summary>2024</summary>
 
@@ -187,7 +187,7 @@ Meeting process is documented:
 
 <details>
 <summary>2019</summary>
-  
+
    * [CG January 8th video call](main/2019/CG-01-08.md)
    * [WG January 16th video call](main/2019/WG-01-16.md)
    * [CG January 22nd video call](main/2019/CG-01-22.md)


### PR DESCRIPTION
## Summary

Correct the meeting process links in the main README

## Details

- these are the first meeting links in the README and were incorrect/out-of-date 😅
  - update to the new pages after #1650

- misc `markdownlint` whitespace changes