### PR TITLE
Remove the link to the phase 0 proposal list.

### DIFF
--- a/process/phases.md
+++ b/process/phases.md
@@ -37,7 +37,7 @@ During this phase:
 
   1. An issue is filed on the [design repository](https://github.com/WebAssembly/design/issues) to present the idea.
   1. Discussion on the feature occurs on the issue.
-  1. A champion or champions emerge. They may add the proposal to the [proposal list](https://github.com/WebAssembly/proposals/blob/main/README.md) at phase 0.
+  1. A champion or champions emerge.
   1. The champion(s) put together a somewhat-formal description of the feature in their own GitHub repository or on the issue.
 
 ## 1. Feature Proposal [Community Group]


### PR DESCRIPTION
The phase-0 process linked to the proposal repo's phase-0 proposals list, however phase-0 proposals are already being tracked in the design repo's issue tracker, so it isn't worth it to manually maintain a separate phase-0 feature list in the proposals repo.