### PR TITLE
Update CG-03-11.md

### DIFF
--- a/main/2025/CG-03-11.md
+++ b/main/2025/CG-03-11.md
@@ -14,6 +14,7 @@ No registration is required for VC meetings. The meeting is open to CG members o
 
 1. Opening
 1. Proposals and discussions
+  - Discussion of (https://github.com/WebAssembly/js-string-builtins/issues/47) with action item to register a `wasm:` scheme with IANA (Ryan Hunt, 15 min)
   - SpecTec discussion and poll ([repo](https://github.com/Wasm-DSL/spectec/tree/main/spectec)) (Andreas Rossberg, 45 min)
 1. Closure
 


### PR DESCRIPTION
I'd like to discuss [1] and see how the CG would feel about registering a provisional `wasm:` scheme with IANA.

15 minutes is a little bit tight for discussing this, but I don't want to wait until Mar 25 to get this moving. I can try to have a hard stop to make sure we don't prevent the SpecTec poll.

[1] https://github.com/WebAssembly/js-string-builtins/issues/47