### PR TITLE
Add slides for ESM integration item

### DIFF
--- a/main/2025/CG-03-25.md
+++ b/main/2025/CG-03-25.md
@@ -16,7 +16,7 @@ No registration is required for VC meetings. The meeting is open to CG members o
 1. Proposals and discussions
    1. Final request for [scheduling constraints](https://github.com/WebAssembly/meetings/issues/1781) for the next in-person meeting (Thomas Lively, brief)
    1. Update on the custom-page-sizes proposal and vote for phase 3 (Nick Fitzgerald, 20 minutes)
-   1. Temperature check on JS builtin interop & the ESM Integration (Guy Bedford, 25 minutes)
+   1. Temperature check on JS builtin interop & the ESM Integration [slides](https://docs.google.com/presentation/d/1DAvEoNWOvOQcPWjZN8oKG_6tcft9qAH881Kn0pxmQCc/edit?usp=sharing) (Guy Bedford, 25 minutes)
    1. Discussion of (https://github.com/WebAssembly/js-string-builtins/issues/47) with action item to register a `wasm:` scheme with IANA (Ryan Hunt, 15 min)
 1. Closure
 


### PR DESCRIPTION
Adds the slides link from today, and also for inclusion in the notes. If there's a better way for me to integrate this please do just let me know as well.