### PR TITLE
cancel WASI 2025-04-03

### DIFF
--- a/wasi/2025/WASI-04-03.md
+++ b/wasi/2025/WASI-04-03.md
@@ -2,30 +2,10 @@
 
 ## Agenda: April 03 WASI video call
 
-- **Where**: zoom.us (see Registration below)
-- **When**: April 03 2025, 17:00-18:00 UTC
-- **Contact**:
-  - Name: Yosh Wuyts and Bailey Hayes
-  - Email: wasm@yosh.is and bailey@cosmonic.com
+> **_NOTE:_** Cancelled, Kubecon and no agenda items.
 
 ### Registration
 
 The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
 
 If this is your first time attending, please [fill out the registration form](https://docs.google.com/forms/d/e/1FAIpQLSdpO6Lp2L_dZ2_oiDgzjKx7pb7s2YYHjeSIyfHWZZGSKoZKWQ/viewform?usp=sf_link) to receive an invite. Please make sure you have joined the CG as above, and that your name appears on the [membership page](https://www.w3.org/community/webassembly/participants), before registering.
-
-
-## Logistics
-
-The meeting will be on a zoom.us video conference.
-
-## Agenda items
-
-1. Opening, welcome and roll call
-    1. Please help add your name to the meeting notes.
-    1. Please help take notes.
-    1. Thanks!
-1. Announcements
-    1. _Submit a PR to add your announcement here_
-1. Proposals and discussions
-    1. _Submit a PR to add your announcement here_


### PR DESCRIPTION
Proposing to cancel tomorrow's WASI meeting because we have no agenda items, likely in part because Kubecon is happening simultaneously. Thanks!