### PR TITLE
Add a presentation on Lime1.

### DIFF
--- a/main/2025/CG-07-01.md
+++ b/main/2025/CG-07-01.md
@@ -14,6 +14,7 @@ No registration is required for VC meetings. The meeting is open to CG members o
 
 1. Opening
 1. Proposals and discussions
+    1. Presentation: Introducing the [Lime](https://github.com/WebAssembly/tool-conventions/blob/main/Lime.md) family of featuresets (Dan Gohman, 5 minutes)
     1. Discussion: [JS interop design](https://github.com/WebAssembly/custom-descriptors/issues/36) (continued) (Thomas Lively, 55 minutes)
 1. Closure
 


### PR DESCRIPTION
[Lime] is the name of a new series of stable feature sets defined in the [tool conventions] repository, currently with one set: [Lime1]. The goal is to give engines and users a stable target that has more features than the MVP, which is what often gets used instead. I recently heard that not everyone has heard about it yet, so I'd like to give a very brief resentation to the CG.

I'm proposing to insert this presentation before the JS interop topic, because I'm expecting it'll be quick. If people want to ask more questions or dive into how this might to profiles or so, I'll propose we take it offline or schedule time in a later meeting.

[Lime]: https://github.com/WebAssembly/tool-conventions/blob/main/Lime.md
[tool conventions]: https://github.com/WebAssembly/tool-conventions
[Lime1]: https://github.com/WebAssembly/tool-conventions/blob/main/Lime.md#lime1