### PR TITLE
Add WASI 0.3 June Update to WASI-06-26

### DIFF
--- a/wasi/2025/WASI-06-26.md
+++ b/wasi/2025/WASI-06-26.md
@@ -29,4 +29,5 @@ The meeting will be on a zoom.us video conference.
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
     1. Dave Bakker: Add native getter & setter support to WIT. [Slides](https://docs.google.com/presentation/d/1on-QuMkOQ-2GCFcJG0DulxKIEDN4KrxveD--gFIzWyQ/edit?usp=sharing). [Issue](https://github.com/WebAssembly/component-model/issues/235).
-    1. _Submit a PR to add your announcement here_
+    2. Yosh Wuyts: WASI 0.3 June Update
+    3. _Submit a PR to add your announcement here_


### PR DESCRIPTION
Adds the WASI 0.3 June Update as a discussion item in the WASI-06-26 meeting agenda. Thanks!