### PR TITLE
Move CSP to August 12

### DIFF
--- a/main/2025/CG-07-29.md
+++ b/main/2025/CG-07-29.md
@@ -14,8 +14,6 @@ No registration is required for VC meetings. The meeting is open to CG members o
 
 1. Opening
 1. Proposals and discussions
-   1. Update on WebAssembly's part of CSP (Francis McCabe)
-      (Potential vote for phase 4.)
 1. Closure
 
 ## Agenda items for future meetings

--- a/main/2025/CG-08-12.md
+++ b/main/2025/CG-08-12.md
@@ -14,6 +14,8 @@ No registration is required for VC meetings. The meeting is open to CG members o
 
 1. Opening
 1. Proposals and discussions
+   1. Update on WebAssembly's part of CSP (Francis McCabe)
+      (Potential vote for phase 4.)
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
Two of the chairs will not be able to make the July 29 meeting, so move
the possible phase 4 vote to the next meeting.
