### PR TITLE
Add agenda item for WG to advance Threads proposal to phase 5

### DIFF
--- a/main/2025/CG-08-12.md
+++ b/main/2025/CG-08-12.md
@@ -16,6 +16,7 @@ No registration is required for VC meetings. The meeting is open to CG members o
 1. Proposals and discussions
    1. Update on WebAssembly's part of CSP (Francis McCabe)
       (Potential vote for phase 4.)
+   2. Advance Threads proposal to Phase 5 (Marcus Plutowski)
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
From my understanding, three major browser engines (JavaScriptCore, V8, Spidermonkey) have implemented this spec, and it's been stable for around a year now. If there's no further spec work to be done, then we should move it to stage 5. Since there may already be a phase 4 vote for CSP, this seems as good a date as any. 

From reading some past discussions ([e.g.](https://github.com/WebAssembly/meetings/pull/1844)) it doesn't seem like there's a requirement for the sponsor (in this case Conrad Watt) to be the one to add this to the agenda.