### PR TITLE
Also propose Roman as a WASI co-champion for wasi-random.

### DIFF
--- a/wasi/2025/WASI-09-04.md
+++ b/wasi/2025/WASI-09-04.md
@@ -29,5 +29,6 @@ The meeting will be on a zoom.us video conference.
     1. _Submit a PR to add your announcement here_
 1. Proposals and discussions
     1. Vote: Proposing Colin Murphy as co-champion for wasi-clocks,
-       Lann Martin as co-champion for wasi-cli, and Victor Adossi
-       as co-champion for wasi-filesystem.
+       Lann Martin as co-champion for wasi-cli, Victor Adossi
+       as co-champion for wasi-filesystem, and Roman Volosatovs
+       as co-champion for wasi-random.


### PR DESCRIPTION
Adding onto #1879, also propose Roman as a co-champion for wasi-random.