### PR TITLE
Add "JS Text Encoding Builtins" to the agenda

### DIFF
--- a/main/2026/CG-2026-04-21.md
+++ b/main/2026/CG-2026-04-21.md
@@ -17,6 +17,7 @@ No registration is required for VC meetings. The meeting is open to CG members o
    1. [MDN wasm language reference](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference) project (Ryan Hunt, 5 minutes)
    1. [Simplifying JS-API test syncing](https://github.com/WebAssembly/spec/issues/2130) (Ryan Hunt, 15 minutes) 
    1. [Revisiting the "no overloading" design principle](https://github.com/WebAssembly/shared-everything-threads/pull/110#issuecomment-4216333083) (Thomas Lively, 20 minutes)
+   1. [JS Text Encoding Builtins](https://github.com/WebAssembly/design/issues/1583) (daxpedda, 20 minutes)
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
I would like to present the [JS Text Encoding Builtins proposal](https://github.com/WebAssembly/design/issues/1583) in the next meeting.