### PR TITLE
Discussion on in person meeting

### DIFF
--- a/main/2026/CG-2026-05-05.md
+++ b/main/2026/CG-2026-05-05.md
@@ -10,10 +10,10 @@
 
 No registration is required for VC meetings. The meeting is open to CG members only.
 
-## Agenda items
 
 1. Opening
 1. Proposals and discussions
+    * W3C in person meeting scheduling for 1st/2nd/3rd week of August 2026. Hosted by Siemens @ Princeton NJ (Chris Woods)
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
Adding an agenda item to discuss hosting W3C in person meeting in Princeton NJ. Candidate dates include the 1st 3 weeks in August.