### PR TITLE
Siemens refreshment lab tour

### DIFF
--- a/main/2026/CG-2026-08.md
+++ b/main/2026/CG-2026-08.md
@@ -43,7 +43,7 @@
 
 Siemens is happy to provide:
 
-* Continential breakfast each morning at 8:30am
+* Continental breakfast each morning at 8:30am
 * Lunch at 12pm each day
 
 #### Communication

--- a/main/2026/CG-2026-08.md
+++ b/main/2026/CG-2026-08.md
@@ -3,10 +3,10 @@
 ## Table of Contents
 
 * [Agenda for the August meeting](#agenda-for-the-August-meeting-of-the-webassembly-community-group)
-
-   * [Research day](#research-day)
-   * [Registration](#registration)
-   * [Logistics](#logistics)
+  
+  * [Research day](#research-day)
+  * [Registration](#registration)
+  * [Logistics](#logistics)
 
 * [Meeting notes](#meeting-notes)
 
@@ -14,31 +14,37 @@
 
 - **Host**: Siemens
 - **Dates**: Tuesday-Wednesday, August 4-5, 2026
-- **Times**: 09:00 - 17:30 EDT
+- **Times**: 08:30 (breakfast) 09:00 - 17:30 EDT
 - **Video Meeting**:
-    - Instructions TBD will be posted on the [W3C calendar events](https://www.w3.org/groups/cg/webassembly/calendar/).
+  - Instructions TBD will be posted on the [W3C calendar events](https://www.w3.org/groups/cg/webassembly/calendar/).
 - **Location**:
-    - 755 College Rd E, Princeton, NJ 08540, USA
+  - 755 College Rd E, Princeton, NJ 08540, USA
 - **Wifi**: TBD
 - **Code of conduct**:
-    - [Standard WebAssembly code of conduct](https://github.com/WebAssembly/meetings/blob/main/CODE_OF_CONDUCT.md). If you have any questions or concerns, please reach out to [WebAssembly CG chair](mailto:webassembly-cg-chair@chromium.org).
-
+  - [Standard WebAssembly code of conduct](https://github.com/WebAssembly/meetings/blob/main/CODE_OF_CONDUCT.md). If you have any questions or concerns, please reach out to [WebAssembly CG chair](mailto:webassembly-cg-chair@chromium.org).
 
 ### Research Day
 
-- Date & time: Thursday, August 6, 2026. 09:00 - 17:30 EDT
+- Date & time: Thursday, August 6, 2026. 08:30 (breakfast) 09:00 - 17:30 EDT
 - Talk proposal? Fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLScocCpwpP4BplGILPuuyMrqVo4kurWwIi333dH0VQbwZbeb_A/viewform?usp=dialog) by August 1.
 - Agenda TBD
 
 ### Social
 
-- TBD
+- Suggestion: Wednesday Evening, at Triump Brewery. This is in "downtown" Princeton. A place to grab a drink and socialise.
 
 ### Registration
 
 - Fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLSf6avItWAb73oWsh487h2T-YhTDzOK91yx1_IIuVHC3eMHajw/viewform) by July 21.
 
 ### Logistics
+
+#### Refereshments
+
+Siemens is happy to provide:
+
+* Continential breakfast each morning at 8:30am
+* Lunch at 12pm each day
 
 #### Communication
 
@@ -85,6 +91,11 @@ start times if previous sessions run long.
 
 _Please add agenda items and timing constraints below_
 
+- Refereshments
+  - Breakfast each morning @ 8:30am - 9:00am
+  - Lunch each day @ 12 / midday
+- (Optional) Siemens Lab Tour @ 5pm / 5:30pm on Wednesday, before heading to Triumph Brewery (Max Wang - Siemens, 30 mins)
+  On site in Princeton is a Siemens factory automation lab. Max Wang leads the Future of Automation research group in Princeton and is offering to provide a tour. During this tour you can see some of the advanced robotics and automation systems Siemens are prototyping. It is within this context that Siemens foresees the use of WebAssembly.
 - Custom Descriptors Update (Thomas Lively, 30 minutes)
 - Component Model Update (Ryan Hunt/Luke Wagner, 2 hours)
   - Components on the Web (1hr)

--- a/main/2026/CG-2026-08.md
+++ b/main/2026/CG-2026-08.md
@@ -31,7 +31,7 @@
 
 ### Social
 
-- Suggestion: Wednesday Evening, at Triump Brewery. This is in "downtown" Princeton. A place to grab a drink and socialise.
+- _Suggestion_: Wednesday Evening, at Triumph Brewery. This is in "downtown" Princeton. A place to grab a drink and socialize.
 
 ### Registration
 
@@ -91,7 +91,7 @@ start times if previous sessions run long.
 
 _Please add agenda items and timing constraints below_
 
-- Refereshments
+- Refreshments
   - Breakfast each morning @ 8:30am - 9:00am
   - Lunch each day @ 12 / midday
 - (Optional) Siemens Lab Tour @ 5pm / 5:30pm on Wednesday, before heading to Triumph Brewery (Max Wang - Siemens, 30 mins)


### PR DESCRIPTION
Siemens have arranged to provide refreshments at the following times:
* Breakfast at 8:30 - 9am
* Lunch at 12 / midday.

In addition we'd be delighted to offer a tour of our future of automation lab at 5pm on Wednesday. 

While Siemens cannot pay for the evening social activity, we'd recommend heading to the Triumph brewery in downtown Princeton. 

I've added these suggestions to the meeting agenda.