### PR TITLE
Update meeting notes for July 27, 2026

### DIFF
--- a/stack/2026/stack-2026-07-27.md
+++ b/stack/2026/stack-2026-07-27.md
@@ -8,12 +8,33 @@
 
 ## Participants
 
+Sam Lindley
+Francis McCabe
+Amy Yin
+Thomas Lively
+Yury Delendik
+Aleksandr Shefer
+Zalim Basharov
+Andreas Rossberg
+Thibaud Michaud
+Deepti Gandluri
+Ben Titzer
+Daniel Hillerström
+Luke Wagner
+
+
 ## Agenda items
 
 Analysis of WasmFX performance (Francis McCabe)
+Slides are available [here](https://docs.google.com/presentation/d/18ZX3j4Vnr53-iHODn-iNNAGzXf9e3utuNtrU9LcU_V0/edit?usp=sharing)
+
+This meeting was recorded, the recording is available [here](https://us02web.zoom.us/rec/share/OR8WP9VXdUElrkhejEJmIgx8Klgywiw_oe8QjHdEmhCfziRQ4CGR6UfTpkzhCOow.AfzcG6a0H0RVW3_q)
 
 ### Adoption of the agenda
 
 ### Discussion
 
 ### Adjourn
+
+
+


### PR DESCRIPTION
Added participants and agenda details for the meeting.