### PR TITLE
Add a vendor-neutral skill for producing notes from transcripts

### DIFF
--- a/skills/wasm-meeting-notes/SKILL.md
+++ b/skills/wasm-meeting-notes/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: wasm-meeting-notes
+description: Convert raw meeting transcripts (Google Meet or Zoom) into comprehensive meeting minutes in the WebAssembly community group style using an interactive pipeline.
+---
+
+# Wasm Meeting Notes
+
+## Overview
+
+This skill provides an interactive pipeline to process raw meeting transcripts into structured meeting notes (minutes) following the standards of the WebAssembly community groups. The pipeline supports transcripts from both **Google Meet** (Markdown/Docs export) and **Zoom** (WebVTT / VTT / text). The process is broken into distinct steps, allowing for human review and correction at each stage to ensure data integrity and accurate attribution.
+
+## Required Setup
+
+Ensure that the Python processing scripts in `scripts/` are available.
+
+The pipeline is **model-agnostic and LLM vendor-neutral**. You can use any LLM provider (OpenAI, Google Gemini, Anthropic Claude, Groq, Ollama, OpenRouter, DeepSeek, LocalAI, vLLM, etc.) by configuring the appropriate environment variable:
+
+- **OpenAI / OpenAI-compatible:**
+  ```bash
+  export OPENAI_API_KEY="sk-..."
+  # Optional custom endpoint (e.g. Ollama, OpenRouter, Groq, local server):
+  # export OPENAI_BASE_URL="http://localhost:11434/v1"
+  # export OPENAI_MODEL="gpt-4o-mini"
+  ```
+- **Google Gemini:**
+  ```bash
+  export GEMINI_API_KEY="AIza..."
+  # Optional: export GEMINI_MODEL="gemini-2.5-flash"
+  ```
+- **Anthropic Claude:**
+  ```bash
+  export ANTHROPIC_API_KEY="sk-ant-..."
+  # Optional: export ANTHROPIC_MODEL="claude-3-5-haiku-20241022"
+  ```
+- **Generic LLM Configuration:**
+  ```bash
+  export LLM_API_KEY="..."
+  export LLM_BASE_URL="https://api.example.com/v1"
+  export LLM_MODEL="..."
+  # export LLM_PROVIDER="openai" # "openai", "gemini", or "anthropic"
+  ```
+
+## Workflow
+
+Follow these steps strictly in order, pausing after each script execution to ask the user to review the output file and confirm it is acceptable before proceeding.
+
+### 1. Structural Cleanup
+
+This step processes raw transcripts from Google Meet (Markdown/Docs) or Zoom (WebVTT/VTT/plain text), strips headers and timestamps, extracts unique speaker initials, and isolates dialogue turns.
+
+- **Run:** `python3 scripts/process_transcript.py <input_transcript> 01_processed.txt`
+- **Review:** Ask the user to review `01_processed.txt` and confirm there are no missing speakers or formatting errors.
+
+### 2. Untangling Interleaved Speech
+
+This step uses the configured LLM to logically reorder and merge sentences that were interrupted or spoken in fragments, ensuring complete thoughts are grouped together. It also removes lines containing nothing but meaningless filler words.
+
+- **Run:** `python3 scripts/reorder_transcript.py 01_processed.txt 02_reordered.txt`
+- **Review:** The script will log to the console any lines that were dropped (identified as filler). Ask the user to review these logs and the contents of `02_reordered.txt` to ensure no meaningful dialogue was lost.
+
+### 3. Language Cleanup
+
+This step uses the configured LLM line-by-line to surgically fix grammar, remove internal false starts, and clear out verbal tics (ums, uhs) while strictly maintaining the technical meaning and original sentence structure.
+
+- **Run:** `python3 scripts/clean_transcript.py 02_reordered.txt 03_cleaned.txt`
+- **Review:** Ask the user to review `03_cleaned.txt` to verify the language reads cleanly without losing technical nuance.
+
+### 4. Final Formatting
+
+Once `03_cleaned.txt` is approved:
+1. **Identify Attendees:** Extract the full names of all participants from the original transcript to populate the `### Attendees` list as a bulleted list of full names.
+2. **Map Agenda:** Cross-reference the dialogue with the meeting agenda to structure the notes with appropriate markdown headers (e.g. `#### [Agenda Topic]`). Preserve issue links (e.g. `[#102](...)`) if mentioned.
+3. **Draft Minutes:** Move the cleaned statements from `03_cleaned.txt` under their corresponding section headers. Use the boilerplate in [assets/template.md](assets/template.md) if starting from a blank meeting file.
+
+## Guidelines
+
+- **Attribute everything**: Every bullet point must start with speaker initials.
+- **Maintain detail**: Do not summarize away technical nuances. If a tradeoff is discussed, capture all sides.
+- **Strict Adherence:** Do not skip review steps. The user must explicitly approve intermediate text files (`01_processed.txt`, `02_reordered.txt`, `03_cleaned.txt`).

--- a/skills/wasm-meeting-notes/assets/template.md
+++ b/skills/wasm-meeting-notes/assets/template.md
@@ -1,0 +1,42 @@
+![WebAssembly logo](/images/WebAssembly.png)
+
+## Agenda for the [DATE] video call of WebAssembly's [SUBGROUP] Subgroup
+
+- **Where**: Google Meet
+- **When**: [DATE], [TIME] UTC ([TIME] Pacific Time)
+- **Location**: *link on calendar invite*
+
+### Registration
+
+None required. Join the WebAssembly CG and view the joining instructions on the [W3C calendar](https://www.w3.org/events/meetings/).
+
+## Logistics
+
+The meeting will be on a Google Meet video conference.
+No installation is required.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+1. Adoption of the agenda
+1. Proposals and discussion
+    1. [ITEM 1]
+    1. [ITEM 2]
+1. Closure
+
+## Meeting Notes
+
+### Attendees
+
+ - [NAME]
+ - [NAME]
+
+### Discussions
+
+#### [TOPIC]
+
+[INITIALS]: [POINT]
+
+#### [TOPIC]
+
+[INITIALS]: [POINT]

--- a/skills/wasm-meeting-notes/scripts/clean_transcript.py
+++ b/skills/wasm-meeting-notes/scripts/clean_transcript.py
@@ -1,0 +1,69 @@
+import sys
+import time
+from llm_client import call_llm
+
+def clean_line(text):
+    """Calls the configured LLM to clean up a single line of text."""
+    system_instruction = (
+        "You are an expert editor for technical meeting transcripts. Your task is to take a single line of a transcript "
+        "and clean up the language. "
+        "Remove verbal filler words like 'um', 'uh', false starts, stutters, and unnecessary repetition. "
+        "Specifically, ensure that partial thoughts or trailing sentence fragments at the end of the line are removed, as they are usually abandoned thoughts. "
+        "Fix obvious grammatical errors, but maintain the technical meaning and the speaker's original intent and tone. "
+        "DO NOT summarize the text. DO NOT combine it with other lines. "
+        "Return ONLY the cleaned up text. "
+        "If the line is just a short filler (e.g. 'Yeah.', 'Okay.', 'Um.'), you can leave it as is or slightly clean it up, but DO NOT remove it entirely."
+    )
+    try:
+        cleaned = call_llm(system_instruction, text, response_json=False)
+        if cleaned:
+            # Strip accidental surrounding quotes if the model wrapped the entire response
+            if (cleaned.startswith('"') and cleaned.endswith('"')) or (cleaned.startswith("'") and cleaned.endswith("'")):
+                cleaned = cleaned[1:-1].strip()
+            return cleaned
+        return text
+    except Exception as e:
+        print(f"  Warning: Failed to clean line ({e}), preserving original.", file=sys.stderr)
+        return text
+
+def main(input_file, output_file):
+    print(f"Reading from {input_file}...")
+    with open(input_file, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    valid_lines = [line.strip() for line in lines if line.strip()]
+    print(f"Processing {len(valid_lines)} lines through LLM...")
+
+    cleaned_lines = []
+    for i, line in enumerate(valid_lines):
+        print(f"Processing line {i+1}/{len(valid_lines)}...")
+
+        if i > 0:
+            time.sleep(0.5)
+
+        # Separate speaker initials
+        if ': ' in line:
+            speaker, content = line.split(': ', 1)
+        else:
+            speaker = ""
+            content = line
+
+        cleaned_content = clean_line(content)
+
+        if speaker:
+            cleaned_lines.append(f"{speaker}: {cleaned_content}")
+        else:
+            cleaned_lines.append(cleaned_content)
+
+    print(f"\nWriting results to {output_file}...")
+    with open(output_file, 'w', encoding='utf-8') as f:
+        for cl in cleaned_lines:
+            f.write(cl + "\n\n")
+
+    print("Done!")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python clean_transcript.py <input.txt> <output.txt>")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])

--- a/skills/wasm-meeting-notes/scripts/llm_client.py
+++ b/skills/wasm-meeting-notes/scripts/llm_client.py
@@ -1,0 +1,178 @@
+import os
+import sys
+import json
+import urllib.request
+import urllib.error
+
+def get_llm_config():
+    """
+    Resolves the LLM provider, API key, base URL, and model from environment variables.
+    Supports OpenAI-compatible APIs (OpenAI, Ollama, Groq, OpenRouter, DeepSeek, LocalAI, vLLM),
+    Google Gemini, and Anthropic Claude.
+    """
+    provider = os.environ.get("LLM_PROVIDER", "").strip().lower()
+
+    api_key = (
+        os.environ.get("LLM_API_KEY") or
+        os.environ.get("OPENAI_API_KEY") or
+        os.environ.get("GEMINI_API_KEY") or
+        os.environ.get("ANTHROPIC_API_KEY")
+    )
+
+    base_url = (
+        os.environ.get("LLM_BASE_URL") or
+        os.environ.get("OPENAI_BASE_URL") or
+        os.environ.get("ANTHROPIC_BASE_URL") or
+        os.environ.get("GEMINI_BASE_URL")
+    )
+
+    model = (
+        os.environ.get("LLM_MODEL") or
+        os.environ.get("OPENAI_MODEL") or
+        os.environ.get("GEMINI_MODEL") or
+        os.environ.get("ANTHROPIC_MODEL")
+    )
+
+    if not provider:
+        if os.environ.get("ANTHROPIC_API_KEY") or (api_key and api_key.startswith("sk-ant")):
+            provider = "anthropic"
+        elif os.environ.get("GEMINI_API_KEY") or (api_key and api_key.startswith("AIza")):
+            provider = "gemini"
+        elif os.environ.get("OPENAI_API_KEY") or base_url or (api_key and api_key.startswith("sk-")):
+            provider = "openai"
+        else:
+            provider = "openai"
+
+    if not api_key and not base_url:
+        print("Error: No LLM API key or base URL configured.", file=sys.stderr)
+        print("Please set one of the following environment variables:", file=sys.stderr)
+        print("  - LLM_API_KEY (and optional LLM_BASE_URL, LLM_MODEL)", file=sys.stderr)
+        print("  - OPENAI_API_KEY (and optional OPENAI_BASE_URL, OPENAI_MODEL)", file=sys.stderr)
+        print("  - GEMINI_API_KEY (and optional GEMINI_MODEL)", file=sys.stderr)
+        print("  - ANTHROPIC_API_KEY (and optional ANTHROPIC_MODEL)", file=sys.stderr)
+        sys.exit(1)
+
+    return {
+        "provider": provider,
+        "api_key": api_key,
+        "base_url": base_url,
+        "model": model
+    }
+
+def call_llm(system_instruction, user_prompt, response_json=False, temperature=0.1):
+    """
+    Sends a prompt to the configured LLM provider and returns the response string.
+    """
+    config = get_llm_config()
+    provider = config["provider"]
+    api_key = config["api_key"]
+    base_url = config["base_url"]
+    model = config["model"]
+
+    if provider == "gemini":
+        model = model or "gemini-flash-latest"
+        url = (base_url or "https://generativelanguage.googleapis.com/v1beta").rstrip("/") + f"/models/{model}:generateContent?key={api_key}"
+        data = {
+            "systemInstruction": {"parts": [{"text": system_instruction}]},
+            "contents": [{"parts": [{"text": user_prompt}]}],
+            "generationConfig": {
+                "temperature": temperature
+            }
+        }
+        if response_json:
+            data["generationConfig"]["response_mime_type"] = "application/json"
+
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(data).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST"
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                res = json.loads(resp.read().decode("utf-8"))
+                candidates = res.get("candidates", [])
+                if candidates:
+                    parts = candidates[0].get("content", {}).get("parts", [])
+                    if parts and "text" in parts[0]:
+                        return parts[0]["text"].strip()
+                return ""
+        except urllib.error.HTTPError as e:
+            print(f"Gemini API HTTP Error {e.code}: {e.read().decode('utf-8')}", file=sys.stderr)
+            raise
+        except urllib.error.URLError as e:
+            print(f"Gemini API URL Error: {e.reason}", file=sys.stderr)
+            raise
+
+    elif provider == "anthropic":
+        model = model or "claude-3-5-haiku-20241022"
+        url = (base_url or "https://api.anthropic.com/v1").rstrip("/") + "/messages"
+        data = {
+            "model": model,
+            "system": system_instruction,
+            "messages": [{"role": "user", "content": user_prompt}],
+            "temperature": temperature,
+            "max_tokens": 4096
+        }
+        headers = {
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+            "Content-Type": "application/json"
+        }
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(data).encode("utf-8"),
+            headers=headers,
+            method="POST"
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                res = json.loads(resp.read().decode("utf-8"))
+                content = res.get("content", [])
+                if content and "text" in content[0]:
+                    return content[0]["text"].strip()
+                return ""
+        except urllib.error.HTTPError as e:
+            print(f"Anthropic API HTTP Error {e.code}: {e.read().decode('utf-8')}", file=sys.stderr)
+            raise
+        except urllib.error.URLError as e:
+            print(f"Anthropic API URL Error: {e.reason}", file=sys.stderr)
+            raise
+
+    else:  # OpenAI / OpenAI-compatible
+        model = model or "gpt-4o-mini"
+        url = (base_url or "https://api.openai.com/v1").rstrip("/") + "/chat/completions"
+        data = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_instruction},
+                {"role": "user", "content": user_prompt}
+            ],
+            "temperature": temperature
+        }
+        if response_json:
+            data["response_format"] = {"type": "json_object"}
+
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(data).encode("utf-8"),
+            headers=headers,
+            method="POST"
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                res = json.loads(resp.read().decode("utf-8"))
+                choices = res.get("choices", [])
+                if choices:
+                    return choices[0].get("message", {}).get("content", "").strip()
+                return ""
+        except urllib.error.HTTPError as e:
+            print(f"OpenAI-compatible API HTTP Error {e.code}: {e.read().decode('utf-8')}", file=sys.stderr)
+            raise
+        except urllib.error.URLError as e:
+            print(f"OpenAI-compatible API URL Error: {e.reason}", file=sys.stderr)
+            raise

--- a/skills/wasm-meeting-notes/scripts/process_transcript.py
+++ b/skills/wasm-meeting-notes/scripts/process_transcript.py
@@ -1,0 +1,130 @@
+import re
+import sys
+
+def get_initials(name, existing_initials):
+    # Remove parenthetical / bracketed annotations like "(Guest)", "(to Everyone)", etc.
+    clean_name = re.sub(r'\(.*?\)', '', name).strip()
+    clean_name = re.sub(r'\[.*?\]', '', clean_name).strip()
+
+    parts = clean_name.split()
+    if not parts:
+        return "UNK"
+
+    base_initials = "".join(p[0].upper() for p in parts if p and (p[0].isalpha() or p[0].isdigit()))
+    if not base_initials:
+        base_initials = "XX"
+
+    if base_initials not in existing_initials:
+        return base_initials
+
+    # Collision resolution
+    # Try adding the second letter of the last name (e.g. Thomas Long -> TLo)
+    if len(parts) >= 2 and len(parts[-1]) >= 2:
+        candidate = base_initials[:-1] + parts[-1][0:2].capitalize()
+        if candidate not in existing_initials:
+            return candidate
+
+    # Try adding the second letter of the first name (e.g. Thomas Long -> ThL)
+    if len(parts[0]) >= 2:
+        candidate = parts[0][0:2].capitalize() + base_initials[1:]
+        if candidate not in existing_initials:
+            return candidate
+
+    # Fallback to appending a number
+    counter = 1
+    while True:
+        candidate = f"{base_initials}{counter}"
+        if candidate not in existing_initials:
+            return candidate
+        counter += 1
+
+def is_timestamp_or_header(line):
+    # Matches common WebVTT, SRT, and markdown timestamp or header patterns
+    if not line:
+        return True
+    if line.startswith('#'):
+        return True
+    if line == 'WEBVTT' or line.startswith('NOTE') or line.startswith('Kind:') or line.startswith('Language:'):
+        return True
+    # WebVTT / SRT timestamp ranges: 00:03:47.000 --> 00:03:51.000
+    if re.match(r'^\d\d?:\d\d(?::\d\d)?(?:\.\d+)?\s*-->\s*\d\d?:\d\d(?::\d\d)?(?:\.\d+)?', line):
+        return True
+    # Standalone timestamps: ### 00:03:28 or [00:03:28] or 00:03:28
+    if re.match(r'^(?:###\s*)?\[?\d\d?:\d\d(?::\d\d)?(?:\.\d+)?\]?$', line):
+        return True
+    # Cue sequence numbers
+    if re.match(r'^\d+$', line):
+        return True
+    return False
+
+def extract_speaker_and_content(line):
+    # Matches:
+    # **Derek Schuff:** Content
+    # **Derek Schuff**: Content
+    # Derek Schuff: Content
+    # 00:03:47 Derek Schuff: Content
+    speaker_re = re.compile(r'^(?:(?:\d\d?:\d\d(?::\d\d)?(?:\.\d+)?)\s+)?(?:\*\*)?([^*:\n]{2,50}?)(?::\*\*|\*\*:|:\s*|\s*:\s*)(.*)$')
+    m = speaker_re.match(line)
+    if m:
+        speaker_candidate = m.group(1).strip()
+        # Ensure it's a realistic speaker name (1-6 words, doesn't look like a URL scheme)
+        if not speaker_candidate.startswith('http') and len(speaker_candidate.split()) <= 6:
+            return speaker_candidate, m.group(2).strip()
+    return None, line
+
+def main(input_file, output_file):
+    with open(input_file, 'r', encoding='utf-8') as f:
+        raw_lines = f.readlines()
+
+    # First pass: find all speakers and generate unique initials
+    speakers = set()
+    for line in raw_lines:
+        stripped = line.strip().replace('\xa0', ' ').strip()
+        if is_timestamp_or_header(stripped):
+            continue
+        speaker, _ = extract_speaker_and_content(stripped)
+        if speaker:
+            speakers.add(speaker)
+
+    sorted_speakers = sorted(list(speakers))
+    speaker_map = {}
+    existing_initials = set()
+
+    for speaker in sorted_speakers:
+        initials = get_initials(speaker, existing_initials)
+        speaker_map[speaker] = initials
+        existing_initials.add(initials)
+
+    print("Speaker Initials Mapping:")
+    for speaker in sorted_speakers:
+        print(f"  {speaker_map[speaker]}: {speaker}")
+
+    # Second pass: clean up lines and attribute dialogue
+    out_lines = []
+    current_initials = None
+
+    for line in raw_lines:
+        stripped = line.strip().replace('\xa0', ' ').strip()
+        if is_timestamp_or_header(stripped):
+            continue
+
+        speaker, content = extract_speaker_and_content(stripped)
+        if speaker:
+            current_initials = speaker_map[speaker]
+            if content:
+                out_lines.append(f"{current_initials}: {content}")
+        else:
+            if current_initials and stripped:
+                out_lines.append(f"{current_initials}: {stripped}")
+
+    with open(output_file, 'w', encoding='utf-8') as f:
+        for out_line in out_lines:
+            f.write(out_line + "\n\n")
+
+    print(f"\nProcessed {len(out_lines)} dialogue turns written to {output_file}")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python process_transcript.py <input_transcript> <output.txt>")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])

--- a/skills/wasm-meeting-notes/scripts/reorder_transcript.py
+++ b/skills/wasm-meeting-notes/scripts/reorder_transcript.py
@@ -1,0 +1,190 @@
+import sys
+import json
+import time
+import re
+from llm_client import call_llm
+
+def parse_reorder_response(text):
+    """
+    Parses the LLM output into a list of nested index arrays.
+    Handles bare JSON arrays, wrapped JSON objects (e.g. {"lines": [...]}),
+    and markdown code fences.
+    """
+    text = text.strip()
+    if text.startswith('```'):
+        lines = text.splitlines()
+        if lines[0].startswith('```'):
+            lines = lines[1:]
+        if lines and lines[-1].startswith('```'):
+            lines = lines[:-1]
+        text = '\n'.join(lines).strip()
+
+    try:
+        data = json.loads(text)
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            for k in ['lines', 'reordered', 'result', 'indices', 'output']:
+                if k in data and isinstance(data[k], list):
+                    return data[k]
+            for val in data.values():
+                if isinstance(val, list):
+                    return val
+    except json.JSONDecodeError:
+        pass
+
+    m = re.search(r'\[\s*\[.*?\]\s*\]', text, re.DOTALL)
+    if m:
+        try:
+            return json.loads(m.group(0))
+        except json.JSONDecodeError:
+            pass
+
+    m_obj = re.search(r'\{.*?\}', text, re.DOTALL)
+    if m_obj:
+        try:
+            data = json.loads(m_obj.group(0))
+            if isinstance(data, dict):
+                for val in data.values():
+                    if isinstance(val, list):
+                        return val
+        except json.JSONDecodeError:
+            pass
+
+    return None
+
+def reorder_chunk(lines_chunk):
+    """
+    Asks the configured LLM to reorder and merge a chunk of lines logically.
+    """
+    indexed_lines = [f"[{i}] {line}" for i, line in enumerate(lines_chunk)]
+    prompt_text = "\n".join(indexed_lines)
+
+    system_instruction = (
+        "You are an expert editor for technical meeting transcripts. "
+        "You are given a chronological snippet of a transcript where speakers are often interleaving or interrupting each other. "
+        "Your goal is to reorganize these lines so that each speaker's complete thought is grouped together sequentially. "
+        "Additionally, if a speaker has multiple lines that belong together as a single thought (e.g. they were broken up by an interrupter or they just spoke in short fragments), you should merge them. "
+        "If a line is completely meaningless filler (like someone just saying 'Yeah' or 'Right') that does not add to the context, you may omit its index entirely. "
+        "DO NOT summarize, alter, or remove any text other than complete omissions of meaningless filler. "
+        "Respond with a JSON object containing a 'lines' field with an array of arrays of integers, where each sub-array represents a single line in the output. "
+        "If a sub-array has multiple integers, those original lines will be concatenated into one. "
+        "Example input:\n[0] A: Start\n[1] B: Interrupt\n[2] A: End\n"
+        "Example output:\n{\"lines\": [[0, 2], [1]]}"
+    )
+
+    try:
+        raw_resp = call_llm(system_instruction, prompt_text, response_json=True)
+        return parse_reorder_response(raw_resp)
+    except Exception as e:
+        print(f"  Warning: LLM invocation failed ({e}). Falling back to original order.", file=sys.stderr)
+        return None
+
+def get_speaker(line):
+    """Extracts speaker initials from a line (e.g. 'TL: text' -> 'TL')."""
+    if ': ' in line:
+        return line.split(': ', 1)[0]
+    return None
+
+def verify_indices(original_count, nested_indices, chunk):
+    """
+    Verifies that nested indices are valid, contain no duplicates,
+    and only merge lines belonging to the same speaker.
+    """
+    if not isinstance(nested_indices, list):
+        return False, set()
+
+    flat_list = []
+    for item in nested_indices:
+        if isinstance(item, int):
+            flat_list.append(item)
+        elif isinstance(item, list):
+            if not item:
+                return False, set()
+            speakers = [get_speaker(chunk[idx]) for idx in item if isinstance(idx, int) and 0 <= idx < len(chunk)]
+            if len(set(speakers)) > 1:
+                print(f"  Warning: LLM attempted to merge different speakers: {set(speakers)}")
+                return False, set()
+            for sub_item in item:
+                if not isinstance(sub_item, int):
+                    return False, set()
+                flat_list.append(sub_item)
+        else:
+            return False, set()
+
+    expected_set = set(range(original_count))
+    actual_set = set(flat_list)
+
+    if not actual_set.issubset(expected_set):
+        return False, set()
+    if len(flat_list) != len(actual_set):
+        return False, set()
+
+    dropped_indices = expected_set - actual_set
+    return True, dropped_indices
+
+def process_transcript(input_file, output_file, chunk_size=10):
+    print(f"Reading from {input_file}...")
+    with open(input_file, 'r', encoding='utf-8') as f:
+        lines = [line.strip() for line in f.readlines() if line.strip()]
+
+    print(f"Processing {len(lines)} lines in chunks of {chunk_size}...")
+    final_reordered_lines = []
+
+    for i in range(0, len(lines), chunk_size):
+        chunk = lines[i:i + chunk_size]
+
+        if len(chunk) <= 1:
+            final_reordered_lines.extend(chunk)
+            continue
+
+        print(f"Processing chunk {i // chunk_size + 1}/{(len(lines) + chunk_size - 1) // chunk_size}...")
+
+        if i > 0:
+            time.sleep(0.5)
+
+        nested_indices = reorder_chunk(chunk)
+
+        is_valid = False
+        dropped = set()
+        if nested_indices is not None:
+            is_valid, dropped = verify_indices(len(chunk), nested_indices, chunk)
+
+        if is_valid:
+            if dropped:
+                for d in dropped:
+                    print(f"  Line removed (filler): {chunk[d]}")
+
+            for item in nested_indices:
+                if isinstance(item, int):
+                    final_reordered_lines.append(chunk[item])
+                elif isinstance(item, list):
+                    merged_content = []
+                    first_line = True
+                    for idx in item:
+                        line_text = chunk[idx]
+                        if first_line:
+                            merged_content.append(line_text)
+                            first_line = False
+                        else:
+                            if ': ' in line_text:
+                                merged_content.append(line_text.split(': ', 1)[1])
+                            else:
+                                merged_content.append(line_text)
+                    final_reordered_lines.append(" ".join(merged_content))
+        else:
+            print("  Warning: Invalid or missing response from LLM. Falling back to original order for this chunk.")
+            final_reordered_lines.extend(chunk)
+
+    print(f"\nWriting results to {output_file}...")
+    with open(output_file, 'w', encoding='utf-8') as f:
+        for line in final_reordered_lines:
+            f.write(line + "\n\n")
+
+    print("Done!")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python reorder_transcript.py <input.txt> <output.txt>")
+        sys.exit(1)
+    process_transcript(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
Add a skill that runs a sequence of python scripts to process Zoom or Meet transcripts into meeting notes. The skill can be used by any agent and the python scripts can be configured to call out to any LLM provider. The general strategy is to do as much of the processing as possible deterministically, and do the rest by giving the LLM only a small fragment of the document at a time, preventing the LLM from summarizing away important information. The skill also instructs the agent to ask for human review after each step of the processing pipeline.
