### PR TITLE
Stub WASI agendas through 2027

### DIFF
--- a/wasi/2027/WASI-01-07.md
+++ b/wasi/2027/WASI-01-07.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: January 07 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: January 07 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-01-21.md
+++ b/wasi/2027/WASI-01-21.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: January 21 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: January 21 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-02-04.md
+++ b/wasi/2027/WASI-02-04.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: February 04 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: February 04 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-02-18.md
+++ b/wasi/2027/WASI-02-18.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: February 18 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: February 18 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-03-04.md
+++ b/wasi/2027/WASI-03-04.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: March 04 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: March 04 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-03-18.md
+++ b/wasi/2027/WASI-03-18.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: March 18 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: March 18 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-04-01.md
+++ b/wasi/2027/WASI-04-01.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: April 01 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: April 01 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-04-15.md
+++ b/wasi/2027/WASI-04-15.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: April 15 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: April 15 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-04-29.md
+++ b/wasi/2027/WASI-04-29.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: April 29 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: April 29 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-05-13.md
+++ b/wasi/2027/WASI-05-13.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: May 13 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: May 13 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-05-27.md
+++ b/wasi/2027/WASI-05-27.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: May 27 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: May 27 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-06-10.md
+++ b/wasi/2027/WASI-06-10.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: June 10 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: June 10 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-06-24.md
+++ b/wasi/2027/WASI-06-24.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: June 24 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: June 24 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-07-08.md
+++ b/wasi/2027/WASI-07-08.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: July 08 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: July 08 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-07-22.md
+++ b/wasi/2027/WASI-07-22.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: July 22 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: July 22 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-08-05.md
+++ b/wasi/2027/WASI-08-05.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: August 05 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: August 05 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-08-19.md
+++ b/wasi/2027/WASI-08-19.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: August 19 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: August 19 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-09-02.md
+++ b/wasi/2027/WASI-09-02.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: September 02 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: September 02 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-09-16.md
+++ b/wasi/2027/WASI-09-16.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: September 16 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: September 16 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-09-30.md
+++ b/wasi/2027/WASI-09-30.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: September 30 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: September 30 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-10-14.md
+++ b/wasi/2027/WASI-10-14.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: October 14 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: October 14 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-10-28.md
+++ b/wasi/2027/WASI-10-28.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: October 28 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: October 28 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-11-11.md
+++ b/wasi/2027/WASI-11-11.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: November 11 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: November 11 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-11-25.md
+++ b/wasi/2027/WASI-11-25.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: November 25 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: November 25 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-12-09.md
+++ b/wasi/2027/WASI-12-09.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: December 09 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: December 09 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_

--- a/wasi/2027/WASI-12-23.md
+++ b/wasi/2027/WASI-12-23.md
@@ -1,0 +1,28 @@
+![WASI logo](https://raw.githubusercontent.com/WebAssembly/WASI/main/WASI.png)
+
+## Agenda: December 23 WASI video call
+
+- **Location**: *link on W3C [calendar](https://www.w3.org/groups/cg/webassembly/calendar/)*
+- **When**: December 23 2025, 17:00-18:00 UTC
+- **Contact**:
+  - Name: Yosh Wuyts and Bailey Hayes
+  - Email: wasm@yosh.is and bailey@cosmonic.com
+
+### Registration
+
+The meeting is open to CG members only. You can [join the CG here](https://www.w3.org/community/webassembly/).
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_


### PR DESCRIPTION
Creates agenda stubs for WASI through to 2027. Created by running:

```bash
./wasi/gen-agendas --frequency 14 --start 2027-01-07 --template ./WASI/TEMPLATE.md --filename-template="./WASI/%Y/WASI-%m-%d.md" --num 26
```

Thanks!