### PR TITLE
Update CG-2026-09-22.md

### DIFF
--- a/main/2026/CG-2026-09-22.md
+++ b/main/2026/CG-2026-09-22.md
@@ -14,8 +14,9 @@ No registration is required for VC meetings. The meeting is open to CG members o
 
 1. Opening
 1. Proposals and discussions
+    1. Phase 3 vote for acquire-release atomics proposal (Rezvan Mahdavi Hezaveh, 15 minutes)
+    1. Relaxed dead code validation (Conrad Watt, 30 minutes)
     1. Discussion: custom descriptors meta-descriptors ([#43](https://github.com/WebAssembly/custom-descriptors/issues/43)) (Thomas Lively, 15 minutes)
-    2. Phase 3 vote for acquire-release atomics proposal (Rezvan Mahdavi Hezaveh, 15 minutes)
 1. Closure
 
 ## Agenda items for future meetings


### PR DESCRIPTION
Add a discussion of relaxed dead code validation and move the custom descriptors discussion to the end to accommodate a participant time constraint.